### PR TITLE
Removed ConvertFX from the repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.cirdles</groupId>
-            <artifactId>convertfx</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
-        
-        <dependency>
             <groupId>org.loadui</groupId>
             <artifactId>testFx</artifactId>
             <version>3.1.2</version>


### PR DESCRIPTION
Removed ConvertFX from the repo in order to remove external dependencies
and simplify the codebase in preperation for the upcoming refactoring.

The internal NodeToSVGConverter was patched to allow it to correctly
handle clip paths.

In the upcoming months, the plan is to replace all of this with
JavaScript charts, and we'll then be able to produce SVGs with 100%
fidelity.
