### PR TITLE
Fixed zoom behavior on errorellipsechart.js and scatterplot.js

### DIFF
--- a/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
+++ b/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
@@ -238,7 +238,7 @@
         var zoom = d3.behavior.zoom()
                 .x(x)
                 .y(y)
-                .scaleExtent([.1, 25])
+                .scaleExtent([.5, 2.5])
                 .on("zoom", function () {
                     var t = zoom.translate();
                     var tx = t[0];

--- a/src/main/resources/org/cirdles/topsoil/app/scatterplot.js
+++ b/src/main/resources/org/cirdles/topsoil/app/scatterplot.js
@@ -121,6 +121,7 @@
         var zoom = d3.behavior.zoom()
                 .x(chart.x)
                 .y(chart.y)
+                .scaleExtent([0.5, 2.5])
                 .on("zoom", function () {
                     chart.settings.transaction(function (t) {
                         t.set(X_MIN, zoom.x().domain()[0]);


### PR DESCRIPTION
Adjusted the zoom.scaleExtent to errorellipsechart.js zoom behavior and added the missing zoom.scaleExtent to scatterplot.js.