### PR TITLE
Removed JAMA as a dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,6 @@ repositories {
 
 dependencies {
     compile 'org.controlsfx:controlsfx:8.20.8'
-    compile 'gov.nist.math:jama:1.0.3'
     compile 'net.sf.opencsv:opencsv:2.3'
 
     testCompile 'junit:junit:4.10'


### PR DESCRIPTION
Removed JAMA as a dependency because it is no longer being used.