### PR TITLE
Added info flag to `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
 
 before_script: npm install -g buster
 
-script: ./gradlew check busterTest --stacktrace
+script: ./gradlew check busterTest --info --stacktrace


### PR DESCRIPTION
Added `--info` to the `.travis.yml` script in order to receive more
feedback about failing Travis CI builds.