### PR TITLE
Added `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules/
 
 # Vim
 *.swp
+
+# OS X
+.DS_Store


### PR DESCRIPTION
Added `.DS_Store` to `.gitignore` to prevent developers using OS X from
introducing the file into the repository.