### PR TITLE
Fixed tests using menus under OS X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,14 @@ task jarWithDependencies(type: Jar) {
     with jar
 }
 
+test {
+    useJUnit {
+        if (System.getProperty("os.name").startsWith("Mac OS")) {
+            excludeCategories 'org.cirdles.OSXIncompatible'
+        }
+    }
+}
+
 // BEGIN JAVASCRIPT SUPPORT
 javascript.source {
     topsoil {

--- a/src/test/java/org/cirdles/OSXIncompatible.java
+++ b/src/test/java/org/cirdles/OSXIncompatible.java
@@ -1,0 +1,26 @@
+package org.cirdles;
+
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ *
+ * @author John Zeringue
+ */
+public interface OSXIncompatible {
+    
+}

--- a/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
@@ -15,11 +15,11 @@
  */
 package org.cirdles.topsoil.app;
 
+import org.cirdles.OSXIncompatible;
 import javafx.scene.Scene;
-import javafx.scene.control.TabPane;
 import javafx.stage.Stage;
 import org.junit.Test;
-import static org.testfx.api.FxAssert.verifyThat;
+import org.junit.experimental.categories.Category;
 import org.testfx.framework.junit.ApplicationTest;
 /**
  *
@@ -35,6 +35,7 @@ public class TopsoilMainWindowTest extends ApplicationTest {
     }
 
     @Test
+    @Category(OSXIncompatible.class)
     public void testCancelImportFile() {
         clickOn("File").clickOn("Import from TSV").closeCurrentWindow();
     }


### PR DESCRIPTION
Tests that tried to access file menus failed under OS X due to its use
of the system menu bar. This fix adds a JUnit category, `OSXIncompatible`, that
prevents these tests from running on Macs.

To apply this solution to future OS X incompatible tests, apply the
following annotation:

    @Category(OSXIncompatible.class)