### PR TITLE
Fixed `HTML_TEMPLATE` in `JavaScriptChart`

### DIFF
--- a/src/main/java/org/cirdles/topsoil/chart/JavaScriptChart.java
+++ b/src/main/java/org/cirdles/topsoil/chart/JavaScriptChart.java
@@ -90,7 +90,7 @@ public class JavaScriptChart extends BaseChart implements JavaFXDisplayable {
                 }
 
             };
-    
+
     private static final List<VariableFormat> UNCERTAINTY_FORMATS
             = Arrays.asList(
                     ONE_SIGMA_ABSOLUTE,
@@ -129,7 +129,7 @@ public class JavaScriptChart extends BaseChart implements JavaFXDisplayable {
 
         // build the HTML template (comments show implicit elements/tags)
         HTML_TEMPLATE
-                = "<!DOCTYPE html>\n"
+                = ("<!DOCTYPE html>\n"
                 // <html>
                 // <head>
                 + "<style>\n"
@@ -146,7 +146,7 @@ public class JavaScriptChart extends BaseChart implements JavaFXDisplayable {
                 + "<script src=\"%s\"></script>\n" // JS file for chart
                 // </body>
                 // </html>
-                + ""; // fixes autoformatting in Netbeans
+                + "").replaceAll("%20", "%%20"); // excape appropriate percents
     }
 
     private final Collection<Runnable> initializationCallbacks = new ArrayList<>();


### PR DESCRIPTION
Fixed #130 by replacing all instances of `%20` with `%%20`. `JavaScriptChart` uses `HTML_TEMPLATE` as a format string, and `%20` (a URL-encoded space) causes errors in this context. The added percent sign escapes the other, turning the sequence back into `%20` after being run through `String.format`.