### PR TITLE
"Create Data Table" focuses new tab

### DIFF
--- a/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -36,6 +36,7 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SelectionModel;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputDialog;
@@ -74,11 +75,11 @@ public class TopsoilMainWindow extends CustomVBox implements Initializable {
             = APPLICATION_DIRECTORY.resolve("Data Sets");
 
     @FXML
-    private Menu chartsMenu;
+    Menu chartsMenu;
     @FXML
-    private Menu datasetsMenu;
+    Menu datasetsMenu;
     @FXML
-    private TabPane dataTableTabPane;
+    TabPane dataTableTabPane;
 
     // JFB
     private final int ERROR_CHART_REQUIRED_COL_COUNT = 5;
@@ -140,6 +141,10 @@ public class TopsoilMainWindow extends CustomVBox implements Initializable {
         dataTableTab.setContent(dataTable);
 
         dataTableTabPane.getTabs().add(dataTableTab);
+        
+        // focus on new tab
+        SelectionModel<Tab> selectionModel = dataTableTabPane.getSelectionModel();
+        selectionModel.select(dataTableTab);
 
         return dataTableTab;
     }

--- a/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
@@ -17,21 +17,44 @@ package org.cirdles.topsoil.app;
 
 import org.cirdles.OSXIncompatible;
 import javafx.scene.Scene;
+import javafx.scene.control.TabPane;
 import javafx.stage.Stage;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import static org.testfx.api.FxAssert.verifyThat;
 import org.testfx.framework.junit.ApplicationTest;
 /**
  *
  * @author John Zeringue
  */
 public class TopsoilMainWindowTest extends ApplicationTest {
+    
+    private TopsoilMainWindow topsoilMainWindow;
 
     @Override
     public void start(Stage stage) throws Exception {
-        Scene scene = new Scene(new TopsoilMainWindow());
+        topsoilMainWindow = new TopsoilMainWindow();
+        
+        Scene scene = new Scene(topsoilMainWindow);
         stage.setScene(scene);
         stage.show();
+    }
+    
+    @Test
+    public void testFocusOnNewTab() {
+        // ensure there is at least one tab already open
+        clickOn("Create Data Table");
+        
+        // create another tab
+        // should be focused
+        clickOn("Create Data Table");
+        
+        verifyThat(topsoilMainWindow.dataTableTabPane, (TabPane tabPane) -> {
+            int numberOfTabs = tabPane.getTabs().size();
+            int selectedIndex = tabPane.getSelectionModel().getSelectedIndex();
+            
+            return selectedIndex == numberOfTabs - 1;
+        });
     }
 
     @Test
@@ -39,4 +62,5 @@ public class TopsoilMainWindowTest extends ApplicationTest {
     public void testCancelImportFile() {
         clickOn("File").clickOn("Import from TSV").closeCurrentWindow();
     }
+    
 }


### PR DESCRIPTION
Fixes #136 by focusing the new tab when "Create Data Table" is pressed.
In order to ensure future correctness, a test was added.