### PR TITLE
Introduced `DSVDatasetReader` and `DSVDatasetWriter`

### DIFF
--- a/src/main/java/org/cirdles/topsoil/app/utils/DSVDatasetReader.java
+++ b/src/main/java/org/cirdles/topsoil/app/utils/DSVDatasetReader.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.app.utils;
+
+import au.com.bytecode.opencsv.CSVReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import org.cirdles.topsoil.data.Dataset;
+import org.cirdles.topsoil.data.Entry;
+import org.cirdles.topsoil.data.Field;
+import org.cirdles.topsoil.data.NumberField;
+import org.cirdles.topsoil.data.SimpleDataset;
+import org.cirdles.topsoil.data.SimpleEntry;
+import org.cirdles.topsoil.data.TextField;
+
+/**
+ *
+ * @author John Zeringue
+ */
+public class DSVDatasetReader implements DatasetReader {
+    
+    private char delimiter;
+    private boolean expectingHeaders;
+    
+    public DSVDatasetReader(char delimiter) {
+        this(delimiter, true);
+    }
+
+    public DSVDatasetReader(char delimiter, boolean expectingHeaders) {
+        this.delimiter = delimiter;
+        this.expectingHeaders = expectingHeaders;
+    }
+
+    boolean isSquare(List<String[]> lines) {
+        boolean isSquare = true;
+
+        if (!lines.isEmpty()) {
+            int lengthOfFirstLine = lines.get(0).length;
+            isSquare = lines.stream()
+                    .allMatch(line -> line.length == lengthOfFirstLine);
+        }
+
+        return isSquare;
+    }
+    
+    void validate(List<String[]> lines) {
+        if (!isSquare(lines)) {
+            throw new IllegalArgumentException("DSV data must be square");
+        }
+    }
+
+    private static boolean isNumber(String string) {
+        try {
+            Double.valueOf(string);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    int indexOfFirstEntry() {
+        return expectingHeaders ? 1 : 0;
+    }
+
+    Class<? extends Field> fieldType(List<String[]> lines, int column) {
+        Class<? extends Field> fieldType = NumberField.class;
+
+        for (int i = indexOfFirstEntry(); i < lines.size(); i++) {
+            if (!isNumber(lines.get(i)[column])) {
+                fieldType = TextField.class;
+                break;
+            }
+        }
+
+        return fieldType;
+    }
+
+    @Override
+    public Dataset read(InputStream source) throws IOException {
+        Reader reader = new InputStreamReader(source, Charset.forName("UTF-8"));
+        CSVReader dsvReader = new CSVReader(reader, delimiter);
+
+        List<String[]> lines = dsvReader.readAll();
+        validate(lines);
+
+        if (lines.isEmpty()) {
+            return Dataset.EMPTY_DATASET;
+        }
+
+        int headerCount = lines.get(0).length;
+        List<Field<?>> fields = new ArrayList<>(headerCount);
+
+        for (int i = 0; i < headerCount; i++) {
+            final String fieldName
+                    = expectingHeaders ? lines.get(0)[i] : "Field " + i;
+
+            if (fieldType(lines, i) == NumberField.class) {
+                fields.add(new NumberField(fieldName));
+            } else if (fieldType(lines, i) == TextField.class) {
+                fields.add(new TextField(fieldName));
+            }
+        }
+
+        List<Entry> entries = new ArrayList<>(lines.size() - indexOfFirstEntry());
+        for (int i = indexOfFirstEntry(); i < lines.size(); i++) {
+            Entry entry = new SimpleEntry();
+
+            for (int j = 0; j < fields.size(); j++) {
+                Field currentField = fields.get(j);
+                entry.set(currentField,
+                        currentField.getStringConverter().fromString(lines.get(i)[j]));
+            }
+
+            entries.add(entry);
+        }
+
+        return new SimpleDataset(fields, entries);
+    }
+    
+}

--- a/src/main/java/org/cirdles/topsoil/app/utils/DSVDatasetWriter.java
+++ b/src/main/java/org/cirdles/topsoil/app/utils/DSVDatasetWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.app.utils;
+
+import au.com.bytecode.opencsv.CSVWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.List;
+import static java.util.stream.Collectors.toList;
+import org.cirdles.topsoil.data.Dataset;
+import org.cirdles.topsoil.data.Field;
+
+/**
+ *
+ * @author John Zeringue
+ */
+public class DSVDatasetWriter implements DatasetWriter {
+
+    private final char delimiter;
+
+    private CSVWriter dsvWriter;
+
+    public DSVDatasetWriter(char delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public char getDelimiter() {
+        return delimiter;
+    }
+
+    void writeFields(Dataset dataset) {
+        String[] line = dataset.getFields().stream()
+                .map(Field::getName)
+                .toArray(String[]::new);
+
+        dsvWriter.writeNext(line);
+    }
+
+    void writeEntries(Dataset dataset) {
+        List<String[]> lines = dataset.getEntries().stream()
+                .map(entry -> {
+                    return dataset.getFields().stream()
+                            .map(entry::get)
+                            .map(value -> value
+                                    .map(Object::toString)
+                                    .orElse(""))
+                            .toArray(String[]::new);
+                })
+                .collect(toList());
+
+        dsvWriter.writeAll(lines);
+    }
+
+    @Override
+    public void write(Dataset dataset, OutputStream destination)
+            throws IOException {
+
+        Writer writer
+                = new OutputStreamWriter(destination, Charset.forName("UTF-8"));
+        
+        dsvWriter = new CSVWriter(writer, getDelimiter());
+
+        writeFields(dataset);
+        writeEntries(dataset);
+
+        dsvWriter.close();
+        dsvWriter = null; // allow dsvWriter to be garbage collected
+    }
+
+}

--- a/src/main/java/org/cirdles/topsoil/app/utils/TSVDatasetReader.java
+++ b/src/main/java/org/cirdles/topsoil/app/utils/TSVDatasetReader.java
@@ -15,117 +15,18 @@
  */
 package org.cirdles.topsoil.app.utils;
 
-import au.com.bytecode.opencsv.CSVReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import org.cirdles.topsoil.data.Field;
-import org.cirdles.topsoil.data.NumberField;
-import org.cirdles.topsoil.data.SimpleEntry;
-import org.cirdles.topsoil.data.Dataset;
-import org.cirdles.topsoil.data.Entry;
-import org.cirdles.topsoil.data.SimpleDataset;
-import org.cirdles.topsoil.data.TextField;
-
 /**
  *
  * @author John Zeringue <john.joseph.zeringue@gmail.com>
  */
-public class TSVDatasetReader implements DatasetReader {
+public class TSVDatasetReader extends DSVDatasetReader {
 
-    private final boolean expectingHeaders;
+    public TSVDatasetReader() {
+        super('\t');
+    }
 
     public TSVDatasetReader(boolean expectingHeaders) {
-        this.expectingHeaders = expectingHeaders;
-    }
-
-    private static boolean isNumber(String string) {
-        try {
-            Double.valueOf(string);
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
-    }
-
-    @Override
-    public Dataset read(InputStream source) throws IOException {
-        CSVReader tsvReader = new CSVReader(new InputStreamReader(source, "utf-8"), '\t');
-
-        List<String[]> lines = tsvReader.readAll();
-
-        if (!isSquare(lines)) {
-            throw new IllegalArgumentException("TSV data must be square");
-        }
-
-        if (lines.isEmpty()) {
-            return Dataset.EMPTY_DATASET;
-        }
-
-        int headerCount = lines.get(0).length;
-        List<Field> fields = new ArrayList<>(headerCount);
-
-        for (int i = 0; i < headerCount; i++) {
-            final String fieldName
-                    = expectingHeaders ? lines.get(0)[i] : "Field " + i;
-
-            if (fieldType(lines, i) == NumberField.class) {
-                fields.add(new NumberField(fieldName));
-            } else if (fieldType(lines, i) == TextField.class) {
-                fields.add(new TextField(fieldName));
-            }
-        }
-
-        List<Entry> entries = new ArrayList<>(lines.size() - firstRow());
-        for (int i = firstRow(); i < lines.size(); i++) {
-            Entry entry = new SimpleEntry();
-
-            for (int j = 0; j < fields.size(); j++) {
-                Field currentField = fields.get(j);
-                entry.set(currentField,
-                        currentField.getStringConverter().fromString(lines.get(i)[j]));
-            }
-
-            entries.add(entry);
-        }
-
-        return new SimpleDataset(fields, entries);
-    }
-
-    int firstRow() {
-        return expectingHeaders ? 1 : 0;
-    }
-
-    Class<? extends Field> fieldType(List<String[]> lines, int column) {
-        Class<? extends Field> fieldType = NumberField.class;
-
-        for (int i = firstRow(); i < lines.size(); i++) {
-            if (!isNumber(lines.get(i)[column])) {
-                fieldType = TextField.class;
-                break;
-            }
-        }
-
-        return fieldType;
-    }
-
-    boolean isSquare(List<String[]> lines) {
-        boolean isSquare = true;
-
-        if (!lines.isEmpty()) {
-            int expectedLineLength = lines.get(0).length;
-
-            for (String[] line : lines) {
-                if (line.length != expectedLineLength) {
-                    isSquare = false;
-                    break;
-                }
-            }
-        }
-
-        return isSquare;
+        super('\t', expectingHeaders);
     }
 
 }

--- a/src/main/java/org/cirdles/topsoil/app/utils/TSVDatasetWriter.java
+++ b/src/main/java/org/cirdles/topsoil/app/utils/TSVDatasetWriter.java
@@ -15,49 +15,14 @@
  */
 package org.cirdles.topsoil.app.utils;
 
-import au.com.bytecode.opencsv.CSVWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.Charset;
-import org.cirdles.topsoil.data.Dataset;
-import org.cirdles.topsoil.data.Field;
-
 /**
  *
  * @author John Zeringue <john.joseph.zeringue@gmail.com>
  */
-public class TSVDatasetWriter implements DatasetWriter {
+public class TSVDatasetWriter extends DSVDatasetWriter {
 
-    @Override
-    public void write(Dataset dataset, OutputStream destination)
-            throws IOException {
-        Writer outputStreamWriter
-                = new OutputStreamWriter(destination, Charset.forName("UTF-8"));
-
-        try (CSVWriter tsvWriter = new CSVWriter(outputStreamWriter, '\t')) {
-            int numberOfFields = dataset.getFields().size();
-
-            String[] line = new String[numberOfFields];
-
-            for (int i = 0; i < dataset.getFields().size(); i++) {
-                line[i] = dataset.getFields().get(i).getName();
-            }
-
-            tsvWriter.writeNext(line);
-
-            // write data
-            dataset.getEntries().forEach(entry -> {
-                for (int i = 0; i < dataset.getFields().size(); i++) {
-                    Field field = dataset.getFields().get(i);
-                    line[i] = entry.get(field).orElse("").toString();
-                }
-
-                // write current line
-                tsvWriter.writeNext(line);
-            });
-        }
+    public TSVDatasetWriter() {
+        super('\t');
     }
 
 }

--- a/src/main/java/org/cirdles/topsoil/data/Dataset.java
+++ b/src/main/java/org/cirdles/topsoil/data/Dataset.java
@@ -30,7 +30,7 @@ public interface Dataset {
     
     public Optional<String> getName();
 
-    public List<Field> getFields();
+    public List<Field<?>> getFields();
 
     public List<Entry> getEntries();
 

--- a/src/main/java/org/cirdles/topsoil/data/Entry.java
+++ b/src/main/java/org/cirdles/topsoil/data/Entry.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  */
 public interface Entry {
     
-    public <T> Optional<T> get(Field<? super T> field);
+    public <T> Optional<T> get(Field<? extends T> field);
     
     public <T> void set(Field<? super T> field, T value);
     

--- a/src/main/java/org/cirdles/topsoil/data/SimpleDataset.java
+++ b/src/main/java/org/cirdles/topsoil/data/SimpleDataset.java
@@ -14,12 +14,12 @@ import java.util.Optional;
  */
 public class SimpleDataset implements Dataset {
  
-    private final List<Field> fields;
+    private final List<Field<?>> fields;
     private final List<Entry> entries;
     
     private Optional<String> name = Optional.empty();
 
-    public SimpleDataset(List<Field> fields, List<Entry> entries) {
+    public SimpleDataset(List<Field<?>> fields, List<Entry> entries) {
         this.fields = fields;
         this.entries = entries;
     }
@@ -30,7 +30,7 @@ public class SimpleDataset implements Dataset {
     }
 
     @Override
-    public List<Field> getFields() {
+    public List<Field<?>> getFields() {
         return fields;
     }
 

--- a/src/main/java/org/cirdles/topsoil/data/SimpleEntry.java
+++ b/src/main/java/org/cirdles/topsoil/data/SimpleEntry.java
@@ -32,7 +32,7 @@ public class SimpleEntry implements Entry {
     }
 
     @Override
-    public <T> Optional<T> get(Field<? super T> field) {
+    public <T> Optional<T> get(Field<? extends T> field) {
         return Optional.ofNullable((T) fieldsToValues.get(field));
     }
 

--- a/src/test/java/org/cirdles/topsoil/app/utils/TSVDatasetReaderTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/utils/TSVDatasetReaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.app.utils;
+
+import java.io.IOException;
+import org.cirdles.topsoil.data.Dataset;
+import org.cirdles.topsoil.data.Field;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ *
+ * @author John Zeringue
+ */
+public class TSVDatasetReaderTest {
+
+    private final static String tsvWithHeaders
+            = (""
+            + "A B C\n"
+            + "1 2 3\n"
+            + "4 5 6\n"
+            + "").replaceAll(" ", "\t");
+
+    private final static String tsvWithoutHeaders
+            = (""
+            + "1 2 3\n"
+            + "4 5 6\n"
+            + "").replaceAll(" ", "\t");
+
+    private DatasetReader datasetReaderWithHeaders;
+    private DatasetReader datasetReaderWithoutHeaders;
+
+    @Before
+    public void setUpDatasetReader() {
+        datasetReaderWithHeaders = new TSVDatasetReader();
+        datasetReaderWithoutHeaders = new TSVDatasetReader(false);
+    }
+
+    @Test
+    public void testReadsTSVFileWithHeaders() throws IOException {
+        Dataset dataset = datasetReaderWithHeaders.read(tsvWithHeaders);
+
+        assertEquals(3, dataset.getFields().size());
+        assertEquals(2, dataset.getEntries().size());
+
+        Field fieldA = dataset.getFields().get(0);
+        Field fieldC = dataset.getFields().get(2);
+
+        assertEquals("A", fieldA.getName());
+        assertEquals("C", fieldC.getName());
+
+        assertEquals(1., dataset.getEntries().get(0).get(fieldA).get());
+        assertEquals(6., dataset.getEntries().get(1).get(fieldC).get());
+
+    }
+
+    @Test
+    public void testReadsTSVFileWithoutHeaders() throws IOException {
+        Dataset dataset = datasetReaderWithoutHeaders.read(tsvWithoutHeaders);
+
+        assertEquals(3, dataset.getFields().size());
+        assertEquals(2, dataset.getEntries().size());
+
+        Field field0 = dataset.getFields().get(0);
+        Field field2 = dataset.getFields().get(2);
+
+        assertEquals("Field 0", field0.getName());
+        assertEquals("Field 2", field2.getName());
+
+        assertEquals(1., dataset.getEntries().get(0).get(field0).get());
+        assertEquals(6., dataset.getEntries().get(1).get(field2).get());
+    }
+
+    @Test
+    public void testReadsEmptyFileAsEmptyDataset() throws IOException {
+        Dataset dataset = datasetReaderWithHeaders.read("");
+
+        assertTrue(dataset.getFields().isEmpty());
+        assertTrue(dataset.getEntries().isEmpty());
+    }
+
+}

--- a/src/test/java/org/cirdles/topsoil/app/utils/TSVDatasetWriterTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/utils/TSVDatasetWriterTest.java
@@ -39,7 +39,7 @@ public class TSVDatasetWriterTest {
     private static final Field<Number> FIELD_C;
     private static final Field<Number> FIELD_D;
 
-    private static final List<Field> FIELDS = Arrays.asList(
+    private static final List<Field<?>> FIELDS = Arrays.asList(
             FIELD_A = new NumberField("A"),
             FIELD_B = new NumberField("B"),
             FIELD_C = new NumberField("C"),
@@ -69,10 +69,11 @@ public class TSVDatasetWriterTest {
         dataset = new SimpleDataset(FIELDS, entries);
     }
 
-    private static final String EXPECTED_WITH_DEFAULT_CONSTRUCTOR = ""
-            + "\"A\"\t\"B\"\t\"C\"\t\"D\"\n"
-            + "\"1\"\t\"2\"\t\"3\"\t\"4\"\n"
-            + "\"1\"\t\"2\"\t\"3\"\t\"4\"\n";
+    private static final String EXPECTED_WITH_DEFAULT_CONSTRUCTOR = (""
+            + "\"A\" \"B\" \"C\" \"D\"\n"
+            + "\"1\" \"2\" \"3\" \"4\"\n"
+            + "\"1\" \"2\" \"3\" \"4\"\n"
+            + "").replaceAll(" ", "\t");
 
     @Test
     public void testWriteWithDefaultConstructor() throws Exception {


### PR DESCRIPTION
Introduced `DSVDatasetReader` and `DSVDatasetWriter`, generalized
versions of the TSV varieties that can be used to create any sort of
delimeter-separated value (DSV) readers/writers. Tests were added to
verify correctness.

A number of `<?>`s were also added in this commit. These simply prohibit
raw types, keeping things like the stream API working.