### PR TITLE
Make data table editable and propagate changes to charts

### DIFF
--- a/src/main/java/org/cirdles/topsoil/app/EntryRowContextMenu.java
+++ b/src/main/java/org/cirdles/topsoil/app/EntryRowContextMenu.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.app;
+
+import static java.lang.Double.NaN;
+import java.util.Collection;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.stage.WindowEvent;
+import org.cirdles.topsoil.app.table.EntryTableColumn;
+import org.cirdles.topsoil.dataset.entry.Entry;
+import org.cirdles.topsoil.dataset.entry.SimpleEntry;
+import static org.cirdles.topsoil.dataset.field.Fields.ROW;
+import static org.cirdles.topsoil.dataset.field.Fields.SELECTED;
+
+/**
+ *
+ * @author parizotclement
+ */
+public class EntryRowContextMenu extends ContextMenu {
+    
+    private final TableRow<Entry> row;
+    
+    private MenuItem toggleSelectedMenuItem;
+    private MenuItem addRowMenuItem;
+    private MenuItem removeRowMenuItem;
+
+    public EntryRowContextMenu(TableRow<Entry> row) {
+        this.row = row;
+        
+        initializeThis();
+    }
+    
+    TableView<Entry> getTable() {
+        return row.getTableView();
+    }
+    
+    void selectEntries() {
+        getTable().getSelectionModel().getSelectedItems().stream()
+                .forEach(entry -> {
+                    entry.set(SELECTED, true);
+                    
+                    entry.get(ROW).ifPresent(entryRow -> entryRow.setOpacity(1));
+                });
+    }
+    
+    void deselectEntries() {
+        getTable().getSelectionModel().getSelectedItems().stream()
+                .forEach(entry -> {
+                   entry.set(SELECTED, false);
+                   
+                   entry.get(ROW).ifPresent(entryRow -> entryRow.setOpacity(0.35));
+                });
+    }
+    
+    MenuItem toggleSelectedMenuItem() {
+        toggleSelectedMenuItem = new MenuItem();
+        
+        toggleSelectedMenuItem.setOnAction(event -> {
+            if(row.getItem().get(SELECTED).orElse(true)) {
+                deselectEntries();
+            } else {
+                selectEntries();
+            }
+            
+            getTable().getSelectionModel().clearSelection();
+        });
+        
+        return toggleSelectedMenuItem;
+    }
+    
+    MenuItem addRowMenuItem() {
+        addRowMenuItem = new MenuItem("Add row");
+        
+        addRowMenuItem.setOnAction(event -> {
+            int nextIndex = row.getIndex() + 1;
+            Entry entry = new SimpleEntry();
+            
+            getTable().getColumns().stream().forEach(tableColumn -> {
+                EntryTableColumn column = (EntryTableColumn) tableColumn;
+                entry.set(column.getField(), NaN);
+            });
+            
+            getTable().getItems().add(nextIndex, entry);
+            getTable().getSelectionModel().clearAndSelect(nextIndex);
+        });
+        
+        return addRowMenuItem;
+    }
+    
+    MenuItem removeRowMenuItem() {
+        removeRowMenuItem  = new MenuItem();
+        
+        removeRowMenuItem .setOnAction(event -> {
+            Collection<Entry> selectedItems = getTable().getSelectionModel().getSelectedItems();
+            
+            getTable().getItems().removeAll(selectedItems);
+            getTable().getSelectionModel().clearSelection();
+        });
+        
+        return removeRowMenuItem ;
+    }
+    
+    String toggleSelectedMenuItemText() {
+        return row.getItem().get(SELECTED).orElse(true) ? "Deselect" : "Select";
+    }
+    
+    void updateToggleSelectedMenuItem() {
+        toggleSelectedMenuItem.setText(toggleSelectedMenuItemText());
+    }
+    
+    boolean multipleItemsSelected() {
+        return getTable().getSelectionModel().getSelectedItems().size() > 1;
+    }
+    
+    void updateAddRowMenuItem() {
+        addRowMenuItem.setDisable(multipleItemsSelected());
+    }
+    
+    String removeRowMenuItemText() {
+        return multipleItemsSelected() ? "Remove rows" : "Remove row";
+    }
+    
+    void updateRemoveRowMenuItem() {
+        removeRowMenuItem.setText(removeRowMenuItemText());
+    }
+    
+    void updateMenuItems(WindowEvent event) {
+        updateToggleSelectedMenuItem();
+        updateAddRowMenuItem();
+        updateRemoveRowMenuItem();
+    }
+    
+    private void initializeThis() {
+        getItems().addAll(
+                toggleSelectedMenuItem(),
+                addRowMenuItem(),
+                removeRowMenuItem()
+        );
+        
+        setOnShowing(this::updateMenuItems);
+    }
+}

--- a/src/main/java/org/cirdles/topsoil/app/EntryRowFactory.java
+++ b/src/main/java/org/cirdles/topsoil/app/EntryRowFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.app;
+
+import java.util.Optional;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.util.Callback;
+import org.cirdles.topsoil.dataset.entry.Entry;
+import static org.cirdles.topsoil.dataset.field.Fields.ROW;
+import static org.cirdles.topsoil.dataset.field.Fields.SELECTED;
+
+/**
+ * The row Factory for the TSVTable 
+ * Define the Context Menu
+ * 
+ * @author parizotclement
+ */
+public class EntryRowFactory implements Callback<TableView<Entry>, TableRow<Entry>> {
+        
+    @Override
+    public TableRow<Entry> call(TableView<Entry> param) {
+        TableRow<Entry> row = new TableRow<>();
+        row.setContextMenu(new EntryRowContextMenu(row));
+        
+        row.itemProperty().addListener((observable, oldValue, newValue) -> {
+            Optional.ofNullable(newValue).ifPresent(entry -> {
+                entry.set(ROW, row);
+                
+                if(entry.get(SELECTED).orElse(true)) {
+                    row.setOpacity(1);
+                } else {
+                    row.setOpacity(0.35);
+                }
+            });
+        
+        });
+        
+        return row;
+    }
+
+}

--- a/src/main/java/org/cirdles/topsoil/app/TSVTable.java
+++ b/src/main/java/org/cirdles/topsoil/app/TSVTable.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.collections.FXCollections;
+import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableView;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.KeyCode;
@@ -45,12 +46,16 @@ public class TSVTable extends TableView<Entry> {
 
     public TSVTable() {
         this.setEditable(true);
-        
+        this.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
         this.setOnKeyPressed((KeyEvent event) -> {
             if (event.isShortcutDown() && event.getCode().equals(KeyCode.V)) {
                 pasteFromClipboard();
             }
         });
+
+        //Context Menu
+        setRowFactory(new EntryRowFactory());
     }
 
     public TSVTable(Path savePath) {
@@ -59,10 +64,10 @@ public class TSVTable extends TableView<Entry> {
         this.savePath = savePath;
         load();
     }
-    
+
     public void setDataset(Dataset dataset) {
         clear();
-        
+
         // create columns for fields
         dataset.getFields().stream().forEach(field -> {
             if (field instanceof NumberField) {
@@ -73,13 +78,13 @@ public class TSVTable extends TableView<Entry> {
                 getColumns().add(new EntryTableColumn<>(textField));
             }
         });
-        
+
         // set data
         setItems(FXCollections.observableList(dataset.getEntries()));
-        
+
         this.dataset = dataset;
     }
-    
+
     public Dataset getDataset() {
         return dataset;
     }
@@ -90,7 +95,7 @@ public class TSVTable extends TableView<Entry> {
     public void pasteFromClipboard() {
         Tools.yesNoPrompt("Does the pasted data contain headers?", response -> {
             DatasetReader tableReader = new TSVDatasetReader(response);
-            
+
             try {
                 Dataset dataset
                         = tableReader.read(Clipboard.getSystemClipboard().getString());
@@ -112,7 +117,7 @@ public class TSVTable extends TableView<Entry> {
         getItems().clear();
         getColumns().clear();
     }
-    
+
     public void load() {
         if (savePath != null) {
             loadFromPath(savePath);
@@ -130,7 +135,7 @@ public class TSVTable extends TableView<Entry> {
             }
         }
     }
-    
+
     public void save() {
         if (savePath != null) {
             saveToPath(savePath);
@@ -148,7 +153,7 @@ public class TSVTable extends TableView<Entry> {
         }
 
         DatasetWriter tableWriter = new TSVDatasetWriter();
-        
+
         try {
             tableWriter.write(getDataset(), savePath);
         } catch (IOException ex) {
@@ -173,5 +178,4 @@ public class TSVTable extends TableView<Entry> {
     public void setSavePath(Path savePath) {
         this.savePath = savePath;
     }
-
 }

--- a/src/main/java/org/cirdles/topsoil/app/Tools.java
+++ b/src/main/java/org/cirdles/topsoil/app/Tools.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javafx.scene.control.Alert;
 import static javafx.scene.control.ButtonBar.ButtonData.CANCEL_CLOSE;
 import static javafx.scene.control.ButtonType.YES;

--- a/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
@@ -39,6 +40,7 @@ import javafx.scene.control.TextInputDialog;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+import javafx.stage.WindowEvent;
 import org.cirdles.javafx.CustomVBox;
 import org.cirdles.topsoil.app.chart.ChartWindow;
 import org.cirdles.topsoil.app.chart.VariableBindingDialog;
@@ -52,6 +54,7 @@ import org.cirdles.topsoil.chart.Chart;
 import org.cirdles.topsoil.chart.JavaScriptChart;
 import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.DatasetManager;
+
 
 /**
  * FXML Controller class
@@ -251,6 +254,9 @@ public class TopsoilMainWindow extends CustomVBox implements Initializable {
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, null, ex);
             }
+            
+            //set Tab title
+            getCurrentTab().ifPresent(tab -> tab.setText(filePath.getFileName().toString().split("\\.")[0]));
         });
     }
 
@@ -270,7 +276,7 @@ public class TopsoilMainWindow extends CustomVBox implements Initializable {
         new VariableBindingDialog(chart.getVariables(), dataset).showAndWait()
                 .ifPresent(variableContext -> {
                     chart.setData(variableContext);
-
+                  
                     Parent chartWindow = new ChartWindow(chart);
                     Scene scene = new Scene(chartWindow, 1200, 800);
 

--- a/src/main/java/org/cirdles/topsoil/app/table/EntryTableColumn.java
+++ b/src/main/java/org/cirdles/topsoil/app/table/EntryTableColumn.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.app.table;
 
-import java.beans.EventHandler;
 import javafx.beans.value.ObservableValueBase;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.cell.TextFieldTableCell;
@@ -32,8 +31,12 @@ public class EntryTableColumn<T> extends TableColumn<Entry, T> {
     private final Field<T> field;
 
     public EntryTableColumn(Field<T> field) {
+        this.field = field;
+        
         setText(field.getName());
-
+        setCellFactory(TextFieldTableCell.forTableColumn(field.getStringConverter()));       
+        setOnEditCommit(new CellEditEventHandler<>(field)); 
+        
         setCellValueFactory((CellDataFeatures<Entry, T> param) -> new ObservableValueBase<T>() {
             
             @Override
@@ -41,15 +44,9 @@ public class EntryTableColumn<T> extends TableColumn<Entry, T> {
                 return param.getValue().get(field).get();
             }
         });
-        setCellFactory(TextFieldTableCell.forTableColumn(field.getStringConverter()));
-        
-        setOnEditCommit(new CellEditEventHandler<>(field));
+    }  
 
-        this.field = field;
-    }
-    
     public Field<T> getField() {
         return field;
-    }
-    
+    }   
 }

--- a/src/main/java/org/cirdles/topsoil/chart/BaseChart.java
+++ b/src/main/java/org/cirdles/topsoil/chart/BaseChart.java
@@ -44,9 +44,9 @@ public abstract class BaseChart implements Chart {
     @Override
     public void setData(VariableContext variableContext) {
         this.dataset = Optional.ofNullable(variableContext.getDataset());
-        this.variableBindings = Optional.ofNullable(variableContext);
+        this.variableBindings = Optional.ofNullable(variableContext);              
     }
-
+    
     @Override
     public SettingScope getSettingScope() {
         return settingScope;

--- a/src/main/java/org/cirdles/topsoil/dataset/SimpleDataset.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/SimpleDataset.java
@@ -15,10 +15,12 @@
  */
 package org.cirdles.topsoil.dataset;
 
-import org.cirdles.topsoil.dataset.entry.Entry;
 import org.cirdles.topsoil.dataset.field.Field;
 import java.util.List;
 import java.util.Optional;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import org.cirdles.topsoil.dataset.entry.Entry;
 
 /**
  *
@@ -27,13 +29,13 @@ import java.util.Optional;
 public class SimpleDataset implements Dataset {
  
     private final List<Field<?>> fields;
-    private final List<Entry> entries;
+    private final ObservableList<Entry> entries;
     
     private Optional<String> name = Optional.empty();
 
     public SimpleDataset(List<Field<?>> fields, List<Entry> entries) {
         this.fields = fields;
-        this.entries = entries;
+        this.entries = FXCollections.observableArrayList(entries);
     }
 
     @Override
@@ -47,9 +49,9 @@ public class SimpleDataset implements Dataset {
     }
 
     @Override
-    public List<Entry> getEntries() {
+    public ObservableList<Entry> getEntries() {
         return entries;
-    }
+    }    
 
     /**
      * @param name the name to set

--- a/src/main/java/org/cirdles/topsoil/dataset/entry/Entry.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/entry/Entry.java
@@ -23,9 +23,13 @@ import java.util.Optional;
  * @author John Zeringue
  */
 public interface Entry {
-    
+
     public <T> Optional<T> get(Field<? extends T> field);
-    
+
     public <T> void set(Field<? super T> field, T value);
-    
+
+    public void addListener(EntryListener listener);
+
+    public void removeListener(EntryListener listener);
+
 }

--- a/src/main/java/org/cirdles/topsoil/dataset/entry/EntryListener.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/entry/EntryListener.java
@@ -13,28 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.dataset;
+package org.cirdles.topsoil.dataset.entry;
 
 import org.cirdles.topsoil.dataset.field.Field;
-import static java.util.Collections.emptyList;
-import java.util.List;
-import java.util.Optional;
-import javafx.collections.ObservableList;
-import org.cirdles.topsoil.dataset.entry.Entry;
 
 /**
  *
- * @author John Zeringue
+ * @author parizotclement
  */
-public interface Dataset {
-
-    public static final Dataset EMPTY_DATASET
-            = new SimpleDataset(emptyList(), emptyList());
+@FunctionalInterface
+public interface EntryListener {
     
-    public Optional<String> getName();
-
-    public List<Field<?>> getFields();
-
-    public ObservableList<Entry> getEntries();
+    public void changed(Entry entry, Field field);
     
 }

--- a/src/main/java/org/cirdles/topsoil/dataset/entry/SimpleEntry.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/entry/SimpleEntry.java
@@ -15,8 +15,10 @@
  */
 package org.cirdles.topsoil.dataset.entry;
 
+import java.util.ArrayList;
 import org.cirdles.topsoil.dataset.field.Field;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,9 +29,11 @@ import java.util.Optional;
 public class SimpleEntry implements Entry {
 
     private final Map<Field, Object> fieldsToValues;
+    private final List<EntryListener> listeners;
 
     public SimpleEntry() {
         fieldsToValues = new HashMap<>();
+        listeners = new ArrayList<>();
     }
 
     @Override
@@ -40,6 +44,20 @@ public class SimpleEntry implements Entry {
     @Override
     public <T> void set(Field<? super T> field, T value) {
         fieldsToValues.put(field, value);
+        
+        listeners.forEach(listener -> {
+            listener.changed(this, field);
+        });
     }
-    
+
+    @Override
+    public void addListener(EntryListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(EntryListener listener) {
+        listeners.remove(listener);
+    }
+
 }

--- a/src/main/java/org/cirdles/topsoil/dataset/field/BooleanField.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/field/BooleanField.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.dataset.field;
+
+import javafx.util.StringConverter;
+
+/**
+ *
+ * @author parizotclement
+ */
+public class BooleanField extends BaseField<Boolean> {
+
+    public BooleanField(String name) {
+        super(name);
+    }
+
+    @Override
+    public StringConverter<Boolean> getStringConverter() {
+        return new StringConverter<Boolean>() {
+
+            @Override
+            public String toString(Boolean object) {
+                return object.toString();
+            }
+
+            @Override
+            public Boolean fromString(String string) {
+                return Boolean.valueOf(string);
+            }
+            
+        };
+    }
+    
+}

--- a/src/main/java/org/cirdles/topsoil/dataset/field/Fields.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/field/Fields.java
@@ -13,28 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.dataset;
+package org.cirdles.topsoil.dataset.field;
 
-import org.cirdles.topsoil.dataset.field.Field;
-import static java.util.Collections.emptyList;
-import java.util.List;
-import java.util.Optional;
-import javafx.collections.ObservableList;
+import javafx.scene.control.TableRow;
+import javafx.util.StringConverter;
 import org.cirdles.topsoil.dataset.entry.Entry;
 
 /**
  *
- * @author John Zeringue
+ * @author parizotclement
  */
-public interface Dataset {
-
-    public static final Dataset EMPTY_DATASET
-            = new SimpleDataset(emptyList(), emptyList());
+public final class Fields {
     
-    public Optional<String> getName();
+    public static final BooleanField SELECTED = new BooleanField("Selected");
+    
+    public static final Field<TableRow<Entry>> ROW = new Field(){
 
-    public List<Field<?>> getFields();
+        @Override
+        public String getName() {
+            return "Row";
+        }
 
-    public ObservableList<Entry> getEntries();
+        @Override
+        public StringConverter getStringConverter() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+        
+    };
     
 }

--- a/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
+++ b/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
@@ -34,7 +34,7 @@
         var y = chart.y = d3.scale.linear()
                 .range([chart.height, 0]);
 
-        if (data.length > 0) {
+        if (data.length > 0){
             chart.settings.transaction(function (t) {
                 t.set(X_MIN, d3.min(data, function (d) {
                     return d.x - d.sigma_x;

--- a/src/test/java/org/cirdles/TableSelector.java
+++ b/src/test/java/org/cirdles/TableSelector.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles;
+
+import java.util.List;
+import javafx.scene.Node;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.Parent;
+import javafx.scene.control.TableCell;
+
+/**
+ * Utility Class
+ * Allow to select tables, rows and cells for the TestFX tests
+ * 
+ * @author parizotclement
+ * @param <T>
+ */
+public final class TableSelector<T> {
+
+    private final TableView<T> table;
+
+    public TableSelector(TableView<T> table) {
+        this.table = table;
+    }
+
+    /**
+     * @param row Index of the row
+     * @return the corresponding row
+     */
+    public TableRow<T> row(int row) {
+        List<Node> current = table.getChildrenUnmodifiable();
+        while (current.size() == 1) {
+            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
+        }
+
+        current = ((Parent) current.get(1)).getChildrenUnmodifiable();
+        while (!(current.get(0) instanceof TableRow)) {
+            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
+        }
+
+        Node node = current.get(row);
+        if (node instanceof TableRow) {
+            return (TableRow<T>) node;
+        } else {
+            throw new RuntimeException("Expected Group with only TableRows as children");
+        }
+    }
+
+    /**
+     * @param row Index of the row
+     * @param column Index of the column
+     * @return the corresponding cell
+     */
+    public TableCell<T, ?> cell(int row, int column) {
+        List<Node> current = row(row).getChildrenUnmodifiable();
+        while (current.size() == 1 && !(current.get(0) instanceof TableCell)) {
+            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
+        }
+
+        Node node = current.get(column);
+        if (node instanceof TableCell) {
+            return (TableCell<T, ?>) node;
+        } else {
+            throw new RuntimeException("Expected TableRowSkin with only TableCells as children");
+        }
+    }
+}

--- a/src/test/java/org/cirdles/topsoil/app/TSVTableTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/TSVTableTest.java
@@ -23,7 +23,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.TableView;
 import javafx.stage.Stage;
+import org.cirdles.TableSelector;
+import org.cirdles.topsoil.dataset.entry.Entry;
 import org.junit.Test;
 import org.testfx.framework.junit.ApplicationTest;
 
@@ -36,35 +39,41 @@ import static org.testfx.matcher.control.TableViewMatchers.*;
  */
 public class TSVTableTest extends ApplicationTest {
 
+    private static final Logger LOGGER
+            = Logger.getLogger(TSVTableTest.class.getName());
+
+    private TableView<Entry> tsvTable;
+    private TableSelector<Entry> tableSelector;
+
     private Parent getRootNode() {
         // generate path to the sample TSV file
         Path sampleTSVPath = null;
+
         try {
             URI sampleTSV_URI = getClass().getResource("sample.tsv").toURI();
             sampleTSVPath = Paths.get(sampleTSV_URI);
         } catch (URISyntaxException ex) {
-            Logger.getLogger(TSVTableTest.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
         }
-        
-        TSVTable testTSVTable = new TSVTable(sampleTSVPath);
-        testTSVTable.setId("tsvTable");
-        return testTSVTable;
+
+        tsvTable = new TSVTable(sampleTSVPath);
+        tableSelector = new TableSelector(tsvTable);
+
+        return tsvTable;
     }
-    
+
     @Override
     public void start(Stage stage) throws Exception {
         Scene scene = new Scene(getRootNode());
         stage.setScene(scene);
         stage.show();
     }
-    
+
     @Test
     public void tsvTable_should_correctlyLoadABasicTSVFile() {
-        verifyThat("#tsvTable", hasTableCell(29.165688743)); // the first number in the file
-//        verifyThat("#tsvTable", hasTableCell(0.915025602)); // the last number in the file
-        verifyThat("#tsvTable", hasTableCell(0.702153693)); // a number in the middle
-        
-        verifyThat("#tsvTable", hasItems(17)); // sample.tsv contains 17 lines
-    }
-    
+        verifyThat(tsvTable, hasTableCell(29.165688743)); // the first number in the file
+        verifyThat(tsvTable, hasTableCell(0.702153693)); // a number in the middle
+
+        verifyThat(tsvTable, hasItems(17)); // sample.tsv contains 17 lines
+    }   
 }

--- a/src/test/java/org/cirdles/topsoil/app/table/EntryTableColumnTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/table/EntryTableColumnTest.java
@@ -20,17 +20,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.TableCell;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
 import static javafx.scene.input.KeyCode.ENTER;
 import javafx.stage.Stage;
+import org.cirdles.TableSelector;
 import org.cirdles.topsoil.app.TSVTable;
 import org.cirdles.topsoil.app.TSVTableTest;
 import org.cirdles.topsoil.app.Topsoil;
@@ -49,148 +46,78 @@ import static org.testfx.matcher.control.LabeledMatchers.hasText;
  * @author parizotclement
  */
 public class EntryTableColumnTest extends ApplicationTest {
-    
 
-   private Parent getRootNode() {
-     
-       // generate path to the sample TSV file
-       Path sampleTSVPath = null;
-       try {
-           URI sampleTSV_URI = getClass().getResource("../sample.tsv").toURI();
-           sampleTSVPath = Paths.get(sampleTSV_URI);
-       } catch (URISyntaxException ex) {
-           Logger.getLogger(TSVTableTest.class.getName()).log(Level.SEVERE, null, ex);
-       }
+    private TableSelector tableSelector;
 
-       //Create a TSVTable
-       TSVTable testTSVTable = new TSVTable(sampleTSVPath);
-       testTSVTable.setId("tsvTable");
-       
-       //Create a dataset
-       DatasetReader tableReader = new TSVDatasetReader(true);
+    private Parent getRootNode() {
+        // generate path to the sample TSV file
+        Path sampleTSVPath = null;
+        try {
+            URI sampleTSV_URI = getClass().getResource("../sample.tsv").toURI();
+            sampleTSVPath = Paths.get(sampleTSV_URI);
+        } catch (URISyntaxException ex) {
+            Logger.getLogger(TSVTableTest.class.getName()).log(Level.SEVERE, null, ex);
+        }
 
-       try {
-           //Extract the data from the sample file
-           Dataset dataset = tableReader.read(sampleTSVPath);
-           testTSVTable.setDataset(dataset);
-       } catch (IOException ex) {
-           Logger.getLogger(Topsoil.class.getName()).log(Level.SEVERE, null, ex);
-       }
+        //Create a TSVTable
+        TSVTable testTSVTable = new TSVTable(sampleTSVPath);
+        tableSelector = new TableSelector(testTSVTable);
 
-       DatasetWriter tableWriter = new TSVDatasetWriter();
-       try {
-           //Write the extracted data into the table
-           tableWriter.write(testTSVTable.getDataset(), Topsoil.LAST_TABLE_PATH);
-       } catch (IOException ex) {
-           Logger.getLogger(TSVTableTest.class.getName()).log(Level.SEVERE, null, ex);
-       }
+        //Create a dataset
+        DatasetReader tableReader = new TSVDatasetReader(true);
 
-       return testTSVTable;
-               
+        try {
+            //Extract the data from the sample file
+            Dataset dataset = tableReader.read(sampleTSVPath);
+            testTSVTable.setDataset(dataset);
+        } catch (IOException ex) {
+            Logger.getLogger(Topsoil.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        DatasetWriter tableWriter = new TSVDatasetWriter();
+        try {
+            //Write the extracted data into the table
+            tableWriter.write(testTSVTable.getDataset(), Topsoil.LAST_TABLE_PATH);
+        } catch (IOException ex) {
+            Logger.getLogger(TSVTableTest.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        return testTSVTable;
     }
-    
+
     @Override
-    public void start(Stage stage) throws Exception {                    
-        
+    public void start(Stage stage) throws Exception {
         Scene scene = new Scene(getRootNode());
         stage.setScene(scene);
         stage.show();
-    }    
-    
+    }
+
     //Test if the filter is correctly working on a non-number input
     @Test
     public void testInputNotANumber() {
-        TableCell cell = cell("#tsvTable", 0, 0);
-        
+        TableCell cell = tableSelector.cell(0, 0);
+
         //Get the value of the first cell, before any editing
         String value = cell.getText();
-        
+
         doubleClickOn(cell) //Double-click on the first cell
                 .write("test") //Write "test"
                 .push(ENTER) //Press ENTER for committing
                 .push(ENTER); //Press ENTER to close the Warning Dialog
-        
+
         //Check that the first cell content hasn't been modified
         verifyThat(cell, hasText(value));
     }
-    
+
+    //Test if the filter is correctly working on a number input
     @Test
     public void testChangeCellValue() {
-        TableCell cell = cell("#tsvTable", 0, 0);
-        
+        TableCell cell = tableSelector.cell(0, 0);
+
         doubleClickOn(cell)
                 .write("123")
                 .push(ENTER);
-                
+
         verifyThat(cell, hasText("123.0"));
-    }
-    
-    /*
-     * ---TEMPORARY STORAGE---
-     *
-     * Methods taken from https://github.com/TestFX/TestFX/issues/27
-     * Allows to retrieve a row or a cell from a table view, as there is no method yet in TestFX to get them
-     *
-     * These methods are stored here for the moment, until they are integrated to TestFX or a decision is made regarding their place   
-     */
-    
-    
-    /**
-    * @param tableSelector Id of a TableView
-    * @return the corresponding TableView, unless an exception is thrown
-    */
-   private TableView<?> getTableView(String tableSelector) {
-       Node node = lookup(tableSelector).queryFirst();
-       if (!(node instanceof TableView)) {
-            throw new RuntimeException(tableSelector + " selected " + node + " which is not a TableView!");
-       }
-       return (TableView<?>) node;
-   }
-
-    /**
-     * @param tableSelector Id of a TableView
-     * @param row Index of the row
-     * @return the corresponding row
-     */
-    protected TableRow<?> row(String tableSelector, int row) {
-
-        TableView<?> tableView = getTableView(tableSelector);
-
-        List<Node> current = tableView.getChildrenUnmodifiable();
-        while (current.size() == 1) {
-            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
-        }
-
-        current = ((Parent) current.get(1)).getChildrenUnmodifiable();
-        while (!(current.get(0) instanceof TableRow)) {
-            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
-        }
-
-        Node node = current.get(row);
-        if (node instanceof TableRow) {
-            return (TableRow<?>) node;
-        } else {
-            throw new RuntimeException("Expected Group with only TableRows as children");
-        }
-    }
-
-    /**
-     * @param tableSelector Id of a TableView
-     * @param row Index of the row
-     * @param column Index of the column
-     * @return the corresponding cell
-     */
-    protected TableCell<?, ?> cell(String tableSelector, int row, int column) {
-        List<Node> current = row(tableSelector, row).getChildrenUnmodifiable();
-        while (current.size() == 1 && !(current.get(0) instanceof TableCell)) {
-            current = ((Parent) current.get(0)).getChildrenUnmodifiable();
-        }
-
-        Node node = current.get(column);
-        if (node instanceof TableCell) {
-            return (TableCell<?, ?>) node;
-        } else {
-            throw new RuntimeException("Expected TableRowSkin with only TableCells as children");
-        }
     }
 }


### PR DESCRIPTION
Added a listener to the TSVTable
Added a Map<Chart, VariableContext> to the dataset
Added a dataset attribute to the entries

A rough but working solution. The dataset is now linked to each chart/context and the entries are linked to the dataset. As a result the chart is reloaded each time a value is changed. 
It will for sure need some refactoring so as to enhance the performances.
However, the sorting of the columns is still causing some issues as the rows' opacity is not changed.