### PR TITLE
Fixed "Save Data Table"

### DIFF
--- a/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -136,7 +136,9 @@ public class TopsoilMainWindow extends CustomVBox implements Initializable {
 
         textInputDialog.setContentText("Data set name:");
         textInputDialog.showAndWait().ifPresent(datasetName -> {
-            Path datasetPath = DATASETS_DIRECTORY.resolve(datasetName + ".tsv");
+            Path datasetPath = DATASETS_DIRECTORY
+                    .resolve("open")
+                    .resolve(datasetName + ".tsv");
 
             getCurrentTable().ifPresent(table -> table.saveToPath(datasetPath));
             getCurrentTab().ifPresent(tab -> tab.setText(datasetName));


### PR DESCRIPTION
Fixed "Save Data Table" by modifying `TopsoilMainWindow` to work with
`TSVDatasetManager` again.

In the future, `TopsoilMainWindow` should not be directly responsible
for saving TSV files.