### PR TITLE
Improved generic type on `NumberField`

### DIFF
--- a/src/main/java/org/cirdles/topsoil/dataset/field/NumberField.java
+++ b/src/main/java/org/cirdles/topsoil/dataset/field/NumberField.java
@@ -23,18 +23,18 @@ import javafx.util.StringConverter;
  *
  * @author zeringuej
  */
-public class NumberField extends BaseField<Number> {
+public class NumberField extends BaseField<Double> {
 
     public NumberField(String name) {
         super(name);
     }
 
     @Override
-    public StringConverter<Number> getStringConverter() {
-        return new StringConverter<Number>() {
+    public StringConverter<Double> getStringConverter() {
+        return new StringConverter<Double>() {
 
             @Override
-            public String toString(Number number) {
+            public String toString(Double number) {
                 if (number == null) {
                     return "---";
                 }
@@ -43,7 +43,7 @@ public class NumberField extends BaseField<Number> {
             }
 
             @Override
-            public Number fromString(String string) {
+            public Double fromString(String string) {
 
                 //Check for valid numbers
                 try {

--- a/src/test/java/org/cirdles/topsoil/app/dataset/writer/TSVDatasetWriterTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/dataset/writer/TSVDatasetWriterTest.java
@@ -34,10 +34,10 @@ import org.junit.Before;
  */
 public class TSVDatasetWriterTest {
 
-    private static final Field<Number> FIELD_A;
-    private static final Field<Number> FIELD_B;
-    private static final Field<Number> FIELD_C;
-    private static final Field<Number> FIELD_D;
+    private static final Field<Double> FIELD_A;
+    private static final Field<Double> FIELD_B;
+    private static final Field<Double> FIELD_C;
+    private static final Field<Double> FIELD_D;
 
     private static final List<Field<?>> FIELDS = Arrays.asList(
             FIELD_A = new NumberField("A"),
@@ -51,10 +51,10 @@ public class TSVDatasetWriterTest {
     public Entry dummyEntry() {
         Entry entry = new SimpleEntry();
 
-        entry.set(FIELD_A, 1);
-        entry.set(FIELD_B, 2);
-        entry.set(FIELD_C, 3);
-        entry.set(FIELD_D, 4);
+        entry.set(FIELD_A, 1.);
+        entry.set(FIELD_B, 2.);
+        entry.set(FIELD_C, 3.);
+        entry.set(FIELD_D, 4.);
 
         return entry;
     }
@@ -70,10 +70,10 @@ public class TSVDatasetWriterTest {
     }
 
     private static final String EXPECTED_WITH_DEFAULT_CONSTRUCTOR = (""
-            + "\"A\" \"B\" \"C\" \"D\"\n"
-            + "\"1\" \"2\" \"3\" \"4\"\n"
-            + "\"1\" \"2\" \"3\" \"4\"\n"
-            + "").replaceAll(" ", "\t");
+            + "\"A\"   \"B\"   \"C\"   \"D\"\n"
+            + "\"1.0\" \"2.0\" \"3.0\" \"4.0\"\n"
+            + "\"1.0\" \"2.0\" \"3.0\" \"4.0\"\n"
+            + "").replaceAll(" +", "\t");
 
     @Test
     public void testWriteWithDefaultConstructor() throws Exception {

--- a/src/test/java/org/cirdles/topsoil/dataset/field/NumberFieldTest.java
+++ b/src/test/java/org/cirdles/topsoil/dataset/field/NumberFieldTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.dataset.field;
+
+import javafx.util.StringConverter;
+import org.cirdles.topsoil.dataset.entry.SimpleEntry;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ *
+ * @author John Zeringue
+ */
+public class NumberFieldTest {
+    
+    private Field<Double> numberField;
+    private StringConverter<Double> stringConverter;
+    
+    @Before
+    public void setUpField() {
+        numberField = new NumberField("Test Field");
+        stringConverter = numberField.getStringConverter();
+    }
+    
+    @Test
+    public void testGenerics() {
+        new SimpleEntry().set(numberField, 3.07); // should compile
+    }
+    
+    @Test
+    public void testStringConverterConvertsDouble() {
+        assertEquals("3.07", stringConverter.toString(3.07));
+    }
+    
+    @Test
+    public void testStringConverterConvertsNullDouble() {
+        assertEquals("---", stringConverter.toString(null));
+    }
+    
+    @Test
+    public void testStringConverterConvertsString() {
+        assertEquals(3.07, stringConverter.fromString("3.07"), 10e-10);
+    }
+    
+}


### PR DESCRIPTION
Changed superclass of `NumberField` from `Field<Number>` to
`Field<Double>`. The motivation for this was to allow the following
statement to compile:

```java
new SimpleEntry().set(new NumberField("Test Field"), 3.07);
```

Prior to this commit, you would need to cast the `NumberField` to a
`Field<Double>` in the example above.

Tests were added to ensure this and other basic properties of
`NumberField` hold.