### PR TITLE
Removed Gradle `--info`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 before_script: npm install -g buster
 
-script: ./gradlew check busterTest --info
+script: ./gradlew check busterTest
 
 notifications:
   webhooks:


### PR DESCRIPTION
Removed the `info` flag from Gradle in `.travis.yml`, because the output
is not as useful as I had originally hoped. Instead, it just makes the
build log difficult to read.