### PR TITLE
Moved utils package to util

### DIFF
--- a/src/main/java/org/cirdles/topsoil/app/Tools.java
+++ b/src/main/java/org/cirdles/topsoil/app/Tools.java
@@ -21,7 +21,7 @@ import static javafx.scene.control.ButtonBar.ButtonData.CANCEL_CLOSE;
 import static javafx.scene.control.ButtonType.YES;
 import javax.inject.Inject;
 import org.cirdles.topsoil.app.metadata.ApplicationMetadata;
-import org.cirdles.topsoil.app.utils.YesNoAlert;
+import org.cirdles.topsoil.app.util.YesNoAlert;
 
 /**
  * Shortcut tools to be used anywhere in the program.

--- a/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -34,7 +34,7 @@ import org.cirdles.topsoil.app.dataset.reader.CSVDatasetReader;
 import org.cirdles.topsoil.app.dataset.reader.DatasetReader;
 import org.cirdles.topsoil.app.dataset.reader.TSVDatasetReader;
 import org.cirdles.topsoil.app.metadata.ApplicationMetadata;
-import org.cirdles.topsoil.app.utils.GetApplicationDirectoryOperation;
+import org.cirdles.topsoil.app.util.GetApplicationDirectoryOperation;
 import org.cirdles.topsoil.chart.Chart;
 import org.cirdles.topsoil.chart.JavaScriptChart;
 import org.cirdles.topsoil.dataset.Dataset;

--- a/src/main/java/org/cirdles/topsoil/app/chart/ChartWindow.java
+++ b/src/main/java/org/cirdles/topsoil/app/chart/ChartWindow.java
@@ -21,7 +21,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ToolBar;
 import javafx.scene.layout.HBox;
 import org.cirdles.topsoil.app.component.SettingsPanel;
-import org.cirdles.topsoil.app.utils.SVGSaver;
+import org.cirdles.topsoil.app.util.SVGSaver;
 import org.cirdles.topsoil.chart.Chart;
 import org.cirdles.topsoil.chart.JavaScriptChart;
 

--- a/src/main/java/org/cirdles/topsoil/app/util/GetApplicationDirectoryOperation.java
+++ b/src/main/java/org/cirdles/topsoil/app/util/GetApplicationDirectoryOperation.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.cirdles.utils.PlatformDependentOperation;
 
 /**
 *

--- a/src/main/java/org/cirdles/topsoil/app/util/GetDocumentsDirectoryOperation.java
+++ b/src/main/java/org/cirdles/topsoil/app/util/GetDocumentsDirectoryOperation.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.cirdles.utils.PlatformDependentOperation;
 
 /**
  * GetDocumentsDirectoryOperation.java

--- a/src/main/java/org/cirdles/topsoil/app/util/PlatformDependentOperation.java
+++ b/src/main/java/org/cirdles/topsoil/app/util/PlatformDependentOperation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.cirdles.utils;
+package org.cirdles.topsoil.app.util;
 
 /**
  *

--- a/src/main/java/org/cirdles/topsoil/app/util/SVGSaver.java
+++ b/src/main/java/org/cirdles/topsoil/app/util/SVGSaver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;

--- a/src/main/java/org/cirdles/topsoil/app/util/YesNoAlert.java
+++ b/src/main/java/org/cirdles/topsoil/app/util/YesNoAlert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import javafx.scene.control.Alert;
 import static javafx.scene.control.Alert.AlertType.CONFIRMATION;

--- a/src/test/java/org/cirdles/topsoil/app/util/GetApplicationDirectoryOperationTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/util/GetApplicationDirectoryOperationTest.java
@@ -3,7 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/src/test/java/org/cirdles/topsoil/app/util/GetDocumentsDirectoryOperationTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/util/GetDocumentsDirectoryOperationTest.java
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/src/test/java/org/cirdles/topsoil/app/util/SVGSaverTest.java
+++ b/src/test/java/org/cirdles/topsoil/app/util/SVGSaverTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.cirdles.topsoil.app.utils;
+package org.cirdles.topsoil.app.util;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;


### PR DESCRIPTION
Moved utils package to util in order to provide a clear separation for
later spliting the project into modules.