### PR TITLE
Gradle test defaults to headless display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ cache:
 jdk:
 - oraclejdk8
 
-# setup jobs.
-env:
-- _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
-
 before_script: npm install -g buster
 
 script: ./gradlew check busterTest

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,13 @@ task jarWithDependencies(type: Jar) {
 }
 
 test {
+    systemProperty 'java.awt.headless', true
+    systemProperty 'prism.order', 'sw'
+    systemProperty 'prism.text', 't2k'
+    systemProperty 'testfx.headless', true
+    systemProperty 'testfx.robot', 'glass'
+    systemProperty 'testfx.setup.timeout', 2500
+
     useJUnit {
         if (System.getProperty('os.name').startsWith('Mac OS')) {
             excludeCategories 'org.cirdles.OSXIncompatible'


### PR DESCRIPTION
Gradle test now uses a headless display (Monocle) instead of the
operating system default. This makes running tests less intrusive, and
encourages developers to use the same settings locally that we use for
the Travis CI build.