### PR TITLE
Added ability to delete datasets

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -153,21 +153,41 @@ public class TopsoilMainWindow extends CustomVBox<TopsoilMainWindow> {
         reloadDatasetMenu();
     }
 
-    void createDatasetMenuItem(Dataset dataset) {
-        MenuItem datasetMenuItem = new MenuItem(dataset.getName());
+    void createDatasetSubmenu(Dataset dataset) {
+        Menu datasetSubmenu = new Menu(dataset.getName());
 
-        datasetMenuItem.setOnAction(event -> {
-            TopsoilMainWindow.this.loadDataset(dataset);
+        MenuItem loadDatasetMenuItem = new MenuItem("Load dataset");
+        loadDatasetMenuItem.setOnAction(event -> {
+            loadDataset(dataset);
         });
 
-        datasetsMenu.getItems().add(datasetMenuItem);
+        MenuItem deleteDatasetMenuItem = new MenuItem("Delete dataset");
+        deleteDatasetMenuItem.setOnAction(event -> {
+            String confirmationMessage = String.format(
+                    "Are you sure that you want to delete \"%s\"?",
+                    dataset.getName());
+
+            new Alert(Alert.AlertType.CONFIRMATION, confirmationMessage)
+                    .showAndWait()
+                    .filter(response -> response == ButtonType.OK)
+                    .ifPresent(response -> {
+                        datasetsMenu.getItems().remove(datasetSubmenu);
+                        datasetMapper.removeDataset(dataset);
+                    });
+        });
+
+        datasetSubmenu.getItems().addAll(
+                loadDatasetMenuItem,
+                deleteDatasetMenuItem);
+
+        datasetsMenu.getItems().add(datasetSubmenu);
     }
 
     void reloadDatasetMenu() {
         // allows this method to be called multiple times in the same session
         datasetsMenu.getItems().clear();
 
-        datasetMapper.getDatasets().forEach(this::createDatasetMenuItem);
+        datasetMapper.getDatasets().forEach(this::createDatasetSubmenu);
     }
 
     void loadDataset(Dataset dataset) {

--- a/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapper.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapper.java
@@ -28,4 +28,6 @@ public interface DatasetMapper {
 
     List<Dataset> getDatasets();
 
+    void removeDataset(Dataset dataset);
+
 }

--- a/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapperDataset.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapperDataset.java
@@ -15,33 +15,48 @@
  */
 package org.cirdles.topsoil.app.dataset;
 
-import org.cirdles.topsoil.app.dataset.reader.TsvRawDataReader;
+import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.RawData;
-import org.cirdles.topsoil.dataset.SimpleDataset;
+import org.cirdles.topsoil.dataset.entry.Entry;
+import org.cirdles.topsoil.dataset.field.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.util.List;
 
 /**
  * Created by johnzeringue on 9/3/15.
  */
-public class TsvDataset extends SimpleDataset {
+public class DatasetMapperDataset implements Dataset {
 
     private static final Logger LOGGER
-            = LoggerFactory.getLogger(TsvDataset.class);
+            = LoggerFactory.getLogger(DatasetMapperDataset.class);
 
-    private static RawData safeRead(String rawData) {
-        try {
-            return new TsvRawDataReader().read(rawData);
-        } catch (IOException ex) {
-            LOGGER.error(null, ex);
-            throw new RuntimeException(ex);
-        }
+    private Long id;
+    private String name;
+    private RawData rawData;
+
+    public DatasetMapperDataset() {
     }
 
-    public TsvDataset(String name, String rawData) {
-        super(name, safeRead(rawData));
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public List<Field<?>> getFields() {
+        return rawData.getFields();
+    }
+
+    @Override
+    public List<Entry> getEntries() {
+        return rawData.getEntries();
+    }
+
+    @Override
+    public RawData getRawData() {
+        return rawData;
     }
 
 }

--- a/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
@@ -20,11 +20,11 @@
 <mapper namespace="org.cirdles.topsoil.app.dataset.DatasetMapper">
     <resultMap
             id="dataset"
-            type="org.cirdles.topsoil.app.dataset.TsvDataset">
-        <constructor>
-            <arg column="name" javaType="String"/>
-            <arg column="raw_data" javaType="String"/>
-        </constructor>
+            type="org.cirdles.topsoil.app.dataset.DatasetMapperDataset">
+        <id column="id" property="id"/>
+
+        <result column="name" property="name"/>
+        <result column="raw_data" property="rawData"/>
     </resultMap>
 
     <insert id="addDataset">
@@ -34,6 +34,12 @@
 
     <select id="getDatasets"
             resultMap="dataset">
-        SELECT name, raw_data FROM dataset
+        SELECT id, name, raw_data
+        FROM dataset
     </select>
+
+    <delete id="removeDataset">
+        DELETE FROM dataset
+        WHERE id = #{id}
+    </delete>
 </mapper>

--- a/app/src/test/java/org/cirdles/topsoil/app/TsvTableTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/TsvTableTest.java
@@ -19,8 +19,10 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.TableView;
 import javafx.stage.Stage;
-import org.cirdles.topsoil.app.dataset.TsvDataset;
+import org.cirdles.topsoil.app.dataset.reader.TsvRawDataReader;
 import org.cirdles.topsoil.dataset.Dataset;
+import org.cirdles.topsoil.dataset.RawData;
+import org.cirdles.topsoil.dataset.SimpleDataset;
 import org.cirdles.topsoil.dataset.entry.Entry;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -62,8 +64,9 @@ public class TsvTableTest extends ApplicationTest {
 
     private TableView<Entry> tsvTable;
 
-    private Parent getRootNode() {
-        Dataset dataset = new TsvDataset("Test", RAW_DATA);
+    private Parent getRootNode() throws Exception {
+        RawData rawData = new TsvRawDataReader().read(RAW_DATA);
+        Dataset dataset = new SimpleDataset("Test", rawData);
         tsvTable = new TsvTable(dataset);
 
         return tsvTable;

--- a/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
@@ -17,9 +17,12 @@ package org.cirdles.topsoil.app.dataset;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.cirdles.topsoil.app.dataset.reader.TsvRawDataReader;
 import org.cirdles.topsoil.app.flyway.FlywayModule;
 import org.cirdles.topsoil.app.sqlite.SQLiteMyBatisModule;
 import org.cirdles.topsoil.dataset.Dataset;
+import org.cirdles.topsoil.dataset.RawData;
+import org.cirdles.topsoil.dataset.SimpleDataset;
 import org.flywaydb.core.Flyway;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,8 +32,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.google.inject.name.Names.named;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
 
 /**
  * Created by johnzeringue on 9/8/15.
@@ -63,7 +66,8 @@ public class DatasetMapperTest {
 
     @Before
     public void setUp() throws Throwable {
-        dataset = new TsvDataset("Dataset", "A\tB\n1\t2");
+        RawData rawData = new TsvRawDataReader().read("A\tB\n1\t2");
+        dataset = new SimpleDataset("Dataset", rawData);
         datasetMapper = getDatasetMapper();
     }
 
@@ -78,7 +82,7 @@ public class DatasetMapperTest {
     }
 
     @Test
-    public void testGetDatasets() throws Exception {
+    public void testGetDatasets() {
         assertTrue(datasetMapper.getDatasets().isEmpty());
 
         for (int i = 0; i < 3; i++) {
@@ -93,6 +97,18 @@ public class DatasetMapperTest {
                 .getFields()
                 .get(0)
                 .getName());
+    }
+
+    @Test
+    public void testRemoveDataset() {
+        for (int i = 0; i < 3; i++) {
+            datasetMapper.addDataset(dataset);
+        }
+
+        Dataset targetDataset = datasetMapper.getDatasets().get(0);
+        datasetMapper.removeDataset(targetDataset);
+
+        assertThat(datasetMapper.getDatasets(), hasSize(2));
     }
 
 }

--- a/app/src/test/java/org/cirdles/topsoil/app/table/EntryTableColumnTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/table/EntryTableColumnTest.java
@@ -21,8 +21,10 @@ import javafx.scene.control.TableCell;
 import javafx.stage.Stage;
 import org.cirdles.TableSelector;
 import org.cirdles.topsoil.app.TsvTable;
-import org.cirdles.topsoil.app.dataset.TsvDataset;
+import org.cirdles.topsoil.app.dataset.reader.TsvRawDataReader;
 import org.cirdles.topsoil.dataset.Dataset;
+import org.cirdles.topsoil.dataset.RawData;
+import org.cirdles.topsoil.dataset.SimpleDataset;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -64,8 +66,9 @@ public class EntryTableColumnTest extends ApplicationTest {
 
     private TableSelector tableSelector;
 
-    private Parent getRootNode() {
-        Dataset dataset = new TsvDataset("Test", RAW_DATA);
+    private Parent getRootNode() throws Exception {
+        RawData rawData = new TsvRawDataReader().read(RAW_DATA);
+        Dataset dataset = new SimpleDataset("Test", rawData);
         TsvTable testTsvTable = new TsvTable(dataset);
         tableSelector = new TableSelector(testTsvTable);
 


### PR DESCRIPTION
Fixed #170 by adding the ability to delete datasets. This feature may be
accessed by navigating to the target dataset in the "Datasets" menu and
using that dataset's submenu.

As part of this change, under the hood, MyBatis now returns a dataset's
SQL id in a hidden field. This can be used to facilitate other updates
as well.