### PR TITLE
Simplified Dataset interface

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/TopsoilMainWindow.java
@@ -141,9 +141,6 @@ public class TopsoilMainWindow extends CustomVBox<TopsoilMainWindow> {
         textInputDialog.showAndWait().ifPresent(datasetName -> {
             getCurrentTable()
                     .map(TsvTable::getDataset)
-                    .map(dataset -> new SimpleDataset(
-                            datasetName,
-                            dataset.getRawData()))
                     .ifPresent(datasetMapper::addDataset);
 
             getCurrentTab().ifPresent(tab -> tab.setText(datasetName));

--- a/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapperDataset.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapperDataset.java
@@ -54,9 +54,4 @@ public class DatasetMapperDataset implements Dataset {
         return rawData.getEntries();
     }
 
-    @Override
-    public RawData getRawData() {
-        return rawData;
-    }
-
 }

--- a/core/src/main/java/org/cirdles/topsoil/dataset/Dataset.java
+++ b/core/src/main/java/org/cirdles/topsoil/dataset/Dataset.java
@@ -32,6 +32,4 @@ public interface Dataset {
 
     public List<Entry> getEntries();
 
-    public RawData getRawData();
-
 }

--- a/core/src/main/java/org/cirdles/topsoil/dataset/SimpleDataset.java
+++ b/core/src/main/java/org/cirdles/topsoil/dataset/SimpleDataset.java
@@ -49,9 +49,4 @@ public class SimpleDataset implements Dataset {
         return rawData.getEntries();
     }
 
-    @Override
-    public RawData getRawData() {
-        return rawData;
-    }
-
 }


### PR DESCRIPTION
Simplified the `Dataset` interface, reverting it to its previous form,
by removing `Dataset#getRawData()`, which I now consider to be redundant
and excessive.