### PR TITLE
Added Travis CI addon to provide newer Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ cache:
 jdk:
 - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 before_script: npm install -g buster
 
 script: ./gradlew check busterTest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     compile 'com.google.inject:guice:4.0'
     compile 'com.google.inject.extensions:guice-multibindings:4.0'
     compile 'net.sf.opencsv:opencsv:2.3'
-    compile 'org.controlsfx:controlsfx:8.20.8'
     compile 'org.flywaydb:flyway-core:3.2.1';
     compile 'org.mybatis:mybatis:3.3.0'
     compile 'org.mybatis:mybatis-guice:3.7'


### PR DESCRIPTION
Added the Travis CI apt addon. This allows the inclusion of the package
`oracle-java8-installer`, which should provide the latest version of
Java 8.

ControlsFX has been removed as a dependency, because the version of Java
installed by the addon, 8u60, has the JavaFX Dialogs API as part of the
standard library. This fixes #69.