### PR TITLE
Added margin to data fits

### DIFF
--- a/app/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
+++ b/app/src/main/resources/org/cirdles/topsoil/app/errorellipsechart.js
@@ -37,19 +37,30 @@
         chart.t = d3.scale.linear();
 
         if (data.length > 0){
+            var dataXMin = d3.min(data, function (d) {
+                return d.x - d.sigma_x;
+            });
+
+            var dataYMin = d3.min(data, function (d) {
+                return d.y - d.sigma_y;
+            });
+
+            var dataXMax = d3.max(data, function (d) {
+                return d.x + d.sigma_x;
+            });
+
+            var dataYMax = d3.max(data, function (d) {
+                return d.y + d.sigma_y;
+            });
+
+            var xRange = dataXMax - dataXMin;
+            var yRange = dataYMax - dataYMin;
+
             chart.settings.transaction(function (t) {
-                t.set(X_MIN, d3.min(data, function (d) {
-                    return d.x - d.sigma_x;
-                }));
-                t.set(Y_MIN, d3.min(data, function (d) {
-                    return d.y - d.sigma_y;
-                }));
-                t.set(X_MAX, d3.max(data, function (d) {
-                    return d.x + d.sigma_x;
-                }));
-                t.set(Y_MAX, d3.max(data, function (d) {
-                    return d.y + d.sigma_y;
-                }));
+                t.set(X_MIN, dataXMin - 0.05 * xRange);
+                t.set(Y_MIN, dataYMin - 0.05 * yRange);
+                t.set(X_MAX, dataXMax + 0.05 * xRange);
+                t.set(Y_MAX, dataYMax + 0.05 * yRange);
             });
         }
 

--- a/app/src/main/resources/org/cirdles/topsoil/app/scatterplot.js
+++ b/app/src/main/resources/org/cirdles/topsoil/app/scatterplot.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2014 CIRDLES.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,19 +26,19 @@
 
     chart.draw = function (data) {
         if (data.length > 0) {
+            var dataXMin = d3.min(data, function (d) { return d.x; });
+            var dataYMin = d3.min(data, function (d) { return d.y; });
+            var dataXMax = d3.max(data, function (d) { return d.x; });
+            var dataYMax = d3.max(data, function (d) { return d.y; });
+
+            var xRange = dataXMax - dataXMin;
+            var yRange = dataYMax - dataYMin;
+
             chart.settings.transaction(function (t) {
-                t.set(X_MIN, d3.min(data, function (d) {
-                    return d.x;
-                }));
-                t.set(Y_MIN, d3.min(data, function (d) {
-                    return d.y;
-                }));
-                t.set(X_MAX, d3.max(data, function (d) {
-                    return d.x;
-                }));
-                t.set(Y_MAX, d3.max(data, function (d) {
-                    return d.y;
-                }));
+                t.set(X_MIN, dataXMin - 0.05 * xRange);
+                t.set(Y_MIN, dataYMin - 0.05 * yRange);
+                t.set(X_MAX, dataXMax + 0.05 * xRange);
+                t.set(Y_MAX, dataYMax + 0.05 * yRange);
             });
         }
 


### PR DESCRIPTION
Fixes #181 by adding a margin to all data fits, including the implicit
one that is performed when a chart is first created and the explicit one
that is triggered by the "Fit Data". This was done for both the
scatterplot and the error ellipse chart.