### PR TITLE
Persist open datasets

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapper.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/dataset/DatasetMapper.java
@@ -26,7 +26,13 @@ public interface DatasetMapper {
 
     void addDataset(Dataset dataset);
 
+    void closeDataset(Dataset dataset);
+
     List<Dataset> getDatasets();
+
+    List<Dataset> getOpenDatasets();
+
+    void openDataset(Dataset dataset);
 
     void removeDataset(Dataset dataset);
 

--- a/app/src/main/resources/db/migration/V1_1_0__Create_open_dataset_table.sql
+++ b/app/src/main/resources/db/migration/V1_1_0__Create_open_dataset_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE open_dataset (
+  id INTEGER PRIMARY KEY,
+  dataset_id INTEGER REFERENCES dataset(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  created datetime DEFAULT CURRENT_TIMESTAMP
+);

--- a/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
@@ -32,11 +32,28 @@
         VALUES (#{name}, #{rawData})
     </insert>
 
+    <delete id="closeDataset">
+        DELETE FROM open_dataset
+        WHERE dataset_id = #{id}
+    </delete>
+
     <select id="getDatasets"
             resultMap="dataset">
         SELECT id, name, raw_data
         FROM dataset
     </select>
+
+    <select id="getOpenDatasets"
+            resultMap="dataset">
+        SELECT dataset.id AS id, name, raw_data
+        FROM dataset
+        INNER JOIN open_dataset ON dataset.id = dataset_id
+    </select>
+
+    <insert id="openDataset">
+        INSERT INTO open_dataset (dataset_id)
+        VALUES (#{id})
+    </insert>
 
     <delete id="removeDataset">
         DELETE FROM dataset

--- a/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.google.inject.name.Names.named;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 /**
@@ -82,6 +82,17 @@ public class DatasetMapperTest {
     }
 
     @Test
+    public void testCloseDataset() throws Exception {
+        datasetMapper.addDataset(dataset);
+        Dataset targetDataset = datasetMapper.getDatasets().get(0);
+        datasetMapper.openDataset(targetDataset);
+
+        assertThat(datasetMapper.getOpenDatasets(), hasSize(1));
+        datasetMapper.closeDataset(targetDataset);
+        assertThat(datasetMapper.getOpenDatasets(), is(empty()));
+    }
+
+    @Test
     public void testGetDatasets() {
         assertTrue(datasetMapper.getDatasets().isEmpty());
 
@@ -97,6 +108,35 @@ public class DatasetMapperTest {
                 .getFields()
                 .get(0)
                 .getName());
+    }
+
+    @Test
+    public void testGetOpenDatasets() {
+        assertThat(datasetMapper.getOpenDatasets(), is(empty()));
+
+        // make sure that removing a dataset removes it from the open list
+        datasetMapper.addDataset(dataset);
+        Dataset targetDataset = datasetMapper.getDatasets().get(0);
+        datasetMapper.openDataset(targetDataset);
+
+        assertThat(datasetMapper.getOpenDatasets(), hasSize(1));
+
+        datasetMapper.removeDataset(targetDataset);
+
+        assertThat(datasetMapper.getOpenDatasets(), is(empty()));
+    }
+
+    @Test
+    public void testOpenDataset() {
+        for (int i = 0; i < 3; i++) {
+            datasetMapper.addDataset(dataset);
+        }
+
+        for (Dataset dataset : datasetMapper.getDatasets()) {
+            datasetMapper.openDataset(dataset);
+        }
+
+        assertThat(datasetMapper.getOpenDatasets(), hasSize(3));
     }
 
     @Test


### PR DESCRIPTION
Persist the list of open datasets by storing them in the SQLite
database. This way, Topsoil can conveniently open previously open
datasets as soon as the program starts.