### PR TITLE
Removed chart context menu

### DIFF
--- a/core/src/main/java/org/cirdles/topsoil/chart/JavaScriptChart.java
+++ b/core/src/main/java/org/cirdles/topsoil/chart/JavaScriptChart.java
@@ -205,6 +205,7 @@ public class JavaScriptChart extends BaseChart implements JavaFXDisplayable {
     private WebView initializeWebView() {
         // initialize webView and associated variables
         webView = new WebView();
+        webView.setContextMenuEnabled(false);
 
         getWebEngine().get().getLoadWorker().stateProperty().addListener(
                 (observable, oldValue, newValue) -> {


### PR DESCRIPTION
Removed charts' context menus, preventing the mysterious "Reload" option
when right-clicking.