### PR TITLE
Fixed open dataset bug

### DIFF
--- a/app/src/main/resources/db/migration/V1_1_1__Fix_open_dataset_table.sql
+++ b/app/src/main/resources/db/migration/V1_1_1__Fix_open_dataset_table.sql
@@ -1,0 +1,13 @@
+ALTER TABLE open_dataset RENAME TO old_open_dataset;
+
+CREATE TABLE open_dataset (
+  id INTEGER PRIMARY KEY,
+  dataset_id INTEGER UNIQUE REFERENCES dataset(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  created datetime DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO open_dataset (dataset_id)
+SELECT DISTINCT dataset_id
+FROM old_open_dataset;
+
+DROP TABLE old_open_dataset;

--- a/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/dataset/DatasetMapper.xml
@@ -51,7 +51,7 @@
     </select>
 
     <insert id="openDataset">
-        INSERT INTO open_dataset (dataset_id)
+        INSERT OR IGNORE INTO open_dataset (dataset_id)
         VALUES (#{id})
     </insert>
 

--- a/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/dataset/DatasetMapperTest.java
@@ -137,6 +137,13 @@ public class DatasetMapperTest {
         }
 
         assertThat(datasetMapper.getOpenDatasets(), hasSize(3));
+
+        // datasets shouldn't be reopened
+        for (Dataset dataset : datasetMapper.getDatasets()) {
+            datasetMapper.openDataset(dataset);
+        }
+
+        assertThat(datasetMapper.getOpenDatasets(), hasSize(3));
     }
 
     @Test


### PR DESCRIPTION
Fixed a bug in the open dataset persistence code where previously open
datasets could reopen, allowing open datasets to multiply on their own
after multiple Topsoil sessions.