### PR TITLE
Fixed SVG saver

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/util/SVGSaver.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/util/SVGSaver.java
@@ -75,8 +75,7 @@ public class SVGSaver {
 
         fileChooser.getExtensionFilters().setAll(
                 new ExtensionFilter("All Files", "*"),
-                new ExtensionFilter("SVG Image", "*.svg")
-        );
+                new ExtensionFilter("SVG Image", "*.svg"));
 
         return fileChooser;
     }


### PR DESCRIPTION
Fixed the SVG saver, which incorrectly specified the extension filter
pattern for all files.