### PR TITLE
Added older JDK to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ cache:
   - "$HOME/.m2/repository"
   - "$HOME/.gradle/caches/"
 
-jdk:
-- oraclejdk8
+jdk: oraclejdk8
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-
+matrix:
+  include:
+    - addons:
+        apt:
+          packages:
+            - oracle-java8-installer # latest version
+    - # older version
+     
 before_script: npm install -g buster
 
 script: ./gradlew check busterTest


### PR DESCRIPTION
Travis should now run two jobs per build. One of them will use the
latest Java 8 JDK (currently 8u66), while the other will use the Travis
default (currently 8u31).

This should help ensure that Topsoil continues to run across different
versions of Java 8.