### PR TITLE
Fixed DSV reader bug

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/dataset/reader/DsvRawDataReader.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/dataset/reader/DsvRawDataReader.java
@@ -30,6 +30,7 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 
@@ -100,7 +101,12 @@ public class DsvRawDataReader extends BaseRawDataReader {
         Reader reader = new InputStreamReader(source, Charset.forName("UTF-8"));
         CSVReader dsvReader = new CSVReader(reader, delimiter);
 
-        List<String[]> lines = dsvReader.readAll();
+        // filter out empty lines
+        List<String[]> lines = dsvReader.readAll().stream()
+                // a line is empty if it only contains the empty string
+                .filter(line -> line.length != 1 || !line[0].equals(""))
+                .collect(Collectors.toList());
+
         validate(lines);
 
         if (lines.isEmpty()) {

--- a/app/src/test/java/org/cirdles/topsoil/app/dataset/reader/TsvRawDataReaderTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/dataset/reader/TsvRawDataReaderTest.java
@@ -44,6 +44,12 @@ public class TsvRawDataReaderTest {
             + "4 5 6\n"
             + "").replaceAll(" ", "\t");
 
+    private static final String tsvWithEmptyLines
+            = (""
+            + "1 2 3\n\n"
+            + "4 5 6\n\n"
+            + "").replaceAll(" ", "\t");
+
     private RawDataReader rawDataReaderWithHeaders;
     private RawDataReader rawDataReaderWithoutHeaders;
 
@@ -73,6 +79,23 @@ public class TsvRawDataReaderTest {
     @Test
     public void testReadsTSVFileWithoutHeaders() throws IOException {
         RawData rawData = rawDataReaderWithoutHeaders.read(tsvWithoutHeaders);
+
+        assertEquals(3, rawData.getFields().size());
+        assertEquals(2, rawData.getEntries().size());
+
+        Field field0 = rawData.getFields().get(0);
+        Field field2 = rawData.getFields().get(2);
+
+        assertEquals("Field 0", field0.getName());
+        assertEquals("Field 2", field2.getName());
+
+        assertEquals(1., rawData.getEntries().get(0).get(field0).get());
+        assertEquals(6., rawData.getEntries().get(1).get(field2).get());
+    }
+
+    @Test
+    public void testReadsTSVFileWithEmptyLines() throws IOException {
+        RawData rawData = rawDataReaderWithoutHeaders.read(tsvWithEmptyLines);
 
         assertEquals(3, rawData.getFields().size());
         assertEquals(2, rawData.getEntries().size());


### PR DESCRIPTION
Fixed #241 by fixing a bug where blank lines (even trailing) would cause
the DSV reader to think the table wasn't square. Now, all blank lines
are ignored, allowing even:

```

A B C

1 2 3

4 5 6

```