### PR TITLE
Added `JavaFXDisplayable` test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ matrix:
             - oracle-java8-installer # latest version
     - # older version
      
-before_script: npm install -g buster
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - npm install -g buster
 
 script: ./gradlew check busterTest
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,15 +58,6 @@ task jarWithDependencies(type: Jar) {
     with jar
 }
 
-test {
-    systemProperty 'java.awt.headless', true
-    systemProperty 'prism.order', 'sw'
-    systemProperty 'prism.text', 't2k'
-    systemProperty 'testfx.headless', true
-    systemProperty 'testfx.robot', 'glass'
-    systemProperty 'testfx.setup.timeout', 2500
-}
-
 dependencies {
     compile project(':core')
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,18 +3,7 @@ plugins {
     id 'com.eriwen.gradle.js' version '1.12.1'
     id 'com.github.rundis.buster' version '0.2.4.2'
 }
-// END JAVASCRIPT SUPPORT
 
-test {
-    systemProperty 'java.awt.headless', true
-    systemProperty 'prism.order', 'sw'
-    systemProperty 'prism.text', 't2k'
-    systemProperty 'testfx.headless', true
-    systemProperty 'testfx.robot', 'glass'
-    systemProperty 'testfx.setup.timeout', 2500
-}
-
-// BEGIN JAVASCRIPT SUPPORT
 javascript.source {
     topsoil {
         js {

--- a/core/src/test/java/org/cirdles/topsoil/plot/JavaFXDisplayableTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/JavaFXDisplayableTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.topsoil.plot;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javafx.scene.layout.VBox;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.swing.SwingUtilities;
+
+/**
+ * Created by johnzeringue on 1/30/16.
+ */
+public class JavaFXDisplayableTest {
+
+    @Rule
+    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
+    public Timeout timeout = Timeout.seconds(5);
+
+    @Test
+    public void testDisplayAsJComponent() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            ((JavaFXDisplayable) () -> new VBox()).displayAsJComponent();
+        });
+    }
+
+}


### PR DESCRIPTION
Added a test for `JavaFXDisplayable` in order to ensure that
`JavaFXDisplayable#displayAsJComponent` isn't causing race conditions on
its own.

As part of this change, I had to move away from headless testing, as
there seem to still be some issues, at least with Swing/AWT on OS X.