### PR TITLE
Removed `VariableContext#getVariables`

### DIFF
--- a/core/src/main/java/org/cirdles/topsoil/plot/SimpleVariableContext.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/SimpleVariableContext.java
@@ -15,11 +15,11 @@
  */
 package org.cirdles.topsoil.plot;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.stream.Collectors;
 import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.field.Field;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class SimpleVariableContext implements VariableContext {
 
@@ -28,13 +28,6 @@ public class SimpleVariableContext implements VariableContext {
 
     public SimpleVariableContext(Dataset dataset) {
         this.dataset = dataset;
-    }
-
-    @Override
-    public Collection<Variable> getVariables() {
-        return getBindings().stream()
-                .map(VariableBinding::getVariable)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/core/src/main/java/org/cirdles/topsoil/plot/VariableContext.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/VariableContext.java
@@ -15,12 +15,13 @@
  */
 package org.cirdles.topsoil.plot;
 
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
 import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.entry.Entry;
 import org.cirdles.topsoil.dataset.field.Field;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  *
@@ -28,13 +29,11 @@ import org.cirdles.topsoil.dataset.field.Field;
  */
 public interface VariableContext {
 
-    public Collection<Variable> getVariables();
+    Dataset getDataset();
 
-    public Dataset getDataset();
+    Collection<VariableBinding> getBindings();
 
-    public Collection<VariableBinding> getBindings();
-
-    public default <T> Optional<VariableBinding<T>> getBindingForVariable(Variable<T> variable) {
+    default <T> Optional<VariableBinding<T>> getBindingForVariable(Variable<T> variable) {
         return getBindings().stream()
                 .filter(binding -> {
                     return Objects.equals(binding.getVariable(), variable);
@@ -44,16 +43,16 @@ public interface VariableContext {
                 .map(binding -> (VariableBinding<T>) binding);
     }
 
-    public default <T> void addBinding(Variable<T> variable, Field<T> field) {
+    default <T> void addBinding(Variable<T> variable, Field<T> field) {
         addBinding(variable, field, variable.getFormats().get(0));
     }
 
-    public default <T> Optional<T> getValue(Variable<T> variable, Entry entry) {
+    default <T> Optional<T> getValue(Variable<T> variable, Entry entry) {
         return getBindingForVariable(variable).map(binding -> {
             return binding.getFormat().normalize(binding, entry);
         });
     }
 
-    public <T> void addBinding(Variable<T> variable, Field<T> field, VariableFormat<T> format);
+    <T> void addBinding(Variable<T> variable, Field<T> field, VariableFormat<T> format);
 
 }


### PR DESCRIPTION
Removed `VariableContext#getVariables` as it's unused and doesn't fit
with future ideas for `VariableContext`.