### PR TITLE
Fixed `getVariables`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ subprojects {
         testCompile 'com.google.code.findbugs:annotations:3.0.0'
         testCompile 'com.google.jimfs:jimfs:1.0'
         testCompile 'junit:junit:4.12'
+        testCompile 'org.assertj:assertj-core:3.3.0'
         testCompile 'org.hamcrest:hamcrest-all:1.3'
         testCompile 'org.mockito:mockito-core:2.0.31-beta'
         testCompile 'org.testfx:openjfx-monocle:1.8.0_20'

--- a/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
@@ -33,18 +33,12 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.cirdles.topsoil.plot.Variables.X;
-import static org.cirdles.topsoil.plot.Variables.SIGMA_X;
-import static org.cirdles.topsoil.plot.Variables.Y;
-import static org.cirdles.topsoil.plot.Variables.SIGMA_Y;
-import static org.cirdles.topsoil.plot.Variables.RHO;
 import static org.cirdles.topsoil.dataset.field.Fields.SELECTED;
 
 /**
@@ -56,12 +50,6 @@ public abstract class JavaScriptPlot extends BasePlot implements JavaFXDisplayab
 
     private static final Logger LOGGER
             = LoggerFactory.getLogger(JavaScriptPlot.class);
-
-    private static final List<Variable> VARIABLES = Arrays.asList(
-            X, SIGMA_X,
-            Y, SIGMA_Y,
-            RHO
-    );
 
     private static final String HTML_TEMPLATE;
 
@@ -154,11 +142,6 @@ public abstract class JavaScriptPlot extends BasePlot implements JavaFXDisplayab
 
     public void fitData() {
         getTopsoil().get().call("showData");
-    }
-
-    @Override
-    public List<Variable> getVariables() {
-        return VARIABLES;
     }
 
     String buildContent() {

--- a/core/src/main/java/org/cirdles/topsoil/plot/standard/EvolutionPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/standard/EvolutionPlot.java
@@ -21,6 +21,15 @@ import org.cirdles.commons.util.ResourceExtractor;
 import org.cirdles.topsoil.plot.Displayable;
 import org.cirdles.topsoil.plot.JavaFXDisplayable;
 import org.cirdles.topsoil.plot.JavaScriptPlot;
+import org.cirdles.topsoil.plot.Variable;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.cirdles.topsoil.plot.Variables.SIGMA_X;
+import static org.cirdles.topsoil.plot.Variables.SIGMA_Y;
+import static org.cirdles.topsoil.plot.Variables.X;
+import static org.cirdles.topsoil.plot.Variables.Y;
 
 /**
  * Created by johnzeringue on 12/1/15.
@@ -46,6 +55,11 @@ public class EvolutionPlot extends JavaScriptPlot {
             }
 
         };
+    }
+
+    @Override
+    public List<Variable> getVariables() {
+        return asList(X, SIGMA_X, Y, SIGMA_Y);
     }
 
 }

--- a/core/src/main/java/org/cirdles/topsoil/plot/standard/ScatterPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/standard/ScatterPlot.java
@@ -18,6 +18,13 @@ package org.cirdles.topsoil.plot.standard;
 import org.cirdles.commons.util.ResourceExtractor;
 import org.cirdles.topsoil.plot.Displayable;
 import org.cirdles.topsoil.plot.JavaScriptPlot;
+import org.cirdles.topsoil.plot.Variable;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.cirdles.topsoil.plot.Variables.X;
+import static org.cirdles.topsoil.plot.Variables.Y;
 
 /**
  *
@@ -44,6 +51,11 @@ public class ScatterPlot extends JavaScriptPlot {
         }
 
         return propertiesPanel;
+    }
+
+    @Override
+    public List<Variable> getVariables() {
+        return asList(X, Y);
     }
 
 }

--- a/core/src/main/java/org/cirdles/topsoil/plot/standard/UncertaintyEllipsePlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/standard/UncertaintyEllipsePlot.java
@@ -18,6 +18,16 @@ package org.cirdles.topsoil.plot.standard;
 import org.cirdles.commons.util.ResourceExtractor;
 import org.cirdles.topsoil.plot.Displayable;
 import org.cirdles.topsoil.plot.JavaScriptPlot;
+import org.cirdles.topsoil.plot.Variable;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.cirdles.topsoil.plot.Variables.RHO;
+import static org.cirdles.topsoil.plot.Variables.SIGMA_X;
+import static org.cirdles.topsoil.plot.Variables.SIGMA_Y;
+import static org.cirdles.topsoil.plot.Variables.X;
+import static org.cirdles.topsoil.plot.Variables.Y;
 
 /**
  *
@@ -44,6 +54,11 @@ public class UncertaintyEllipsePlot extends JavaScriptPlot {
         }
 
         return propertiesPanel;
+    }
+
+    @Override
+    public List<Variable> getVariables() {
+        return asList(X, SIGMA_X, Y, SIGMA_Y, RHO);
     }
 
 }

--- a/core/src/test/java/org/cirdles/topsoil/plot/standard/EvolutionPlotTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/standard/EvolutionPlotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 CIRDLES.
+ * Copyright 2016 CIRDLES.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,18 @@
 package org.cirdles.topsoil.plot.standard;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
-import javafx.stage.Stage;
 import org.cirdles.topsoil.plot.Plot;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.testfx.framework.junit.ApplicationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.cirdles.topsoil.plot.standard.UncertaintyEllipsePlotProperties.TITLE;
 
 /**
- * Created by johnzeringue on 11/11/15.
+ * Created by johnzeringue on 1/31/16.
  */
-public class UncertaintyEllipsePlotTest extends ApplicationTest {
+public class EvolutionPlotTest {
 
     @Rule
     @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
@@ -39,30 +35,14 @@ public class UncertaintyEllipsePlotTest extends ApplicationTest {
 
     private Plot plot;
 
-    @Override
-    public void start(Stage stage) throws Exception {
-        plot = new UncertaintyEllipsePlot();
-
-        Scene scene = new Scene((Parent) plot.displayAsNode());
-        stage.setScene(scene);
-        stage.show();
+    @Before
+    public void setUp() {
+        plot = new EvolutionPlot();
     }
 
     @Test
-    public void testGetProperty() {
-        assertThat(plot.getProperty(TITLE))
-                .isEqualTo("Uncertainty Ellipse Plot");
-    }
-
-    @Test
-    public void testSetProperty() {
-        plot.setProperty(TITLE, "New Title");
-        assertThat(plot.getProperty(TITLE)).isEqualTo("New Title");
-    }
-
-    @Test
-    public void testGetVariables() {
-        assertThat(plot.getVariables()).hasSize(5);
+    public void testGetVariables() throws Exception {
+        assertThat(plot.getVariables()).hasSize(4);
     }
 
 }

--- a/core/src/test/java/org/cirdles/topsoil/plot/standard/ScatterPlotTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/standard/ScatterPlotTest.java
@@ -19,12 +19,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-import org.cirdles.topsoil.plot.Plot;
-import org.cirdles.topsoil.plot.SimplePlotContext;
-import org.cirdles.topsoil.plot.PlotContext;
 import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.RawData;
 import org.cirdles.topsoil.dataset.SimpleDataset;
+import org.cirdles.topsoil.plot.Plot;
+import org.cirdles.topsoil.plot.PlotContext;
+import org.cirdles.topsoil.plot.SimplePlotContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -32,9 +32,8 @@ import org.testfx.framework.junit.ApplicationTest;
 
 import java.util.ArrayList;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.cirdles.topsoil.plot.standard.ScatterPlotProperties.TITLE;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  *
@@ -59,7 +58,7 @@ public class ScatterPlotTest extends ApplicationTest {
 
     @Test
     public void testGetVariables() {
-        plot.getVariables();
+        assertThat(plot.getVariables()).hasSize(2);
     }
 
     @Test
@@ -76,12 +75,12 @@ public class ScatterPlotTest extends ApplicationTest {
     @Test
     public void testProperties() throws Throwable {
         // check a default
-        assertThat(plot.getProperty(TITLE), is("Scatter Plot"));
+        assertThat(plot.getProperty(TITLE)).isEqualTo("Scatter Plot");
 
         plot.setProperty(TITLE, "New Title");
 
         // check that it's changed
-        assertThat(plot.getProperty(TITLE), is("New Title"));
+        assertThat(plot.getProperty(TITLE)).isEqualTo("New Title");
     }
 
 }


### PR DESCRIPTION
Fixed `getVariables` by removing `JavaScriptPlot#getVariables` and
making the existing subclasses provide their own variables instead.

While testing, I added AssertJ, an alternative to Hamcrest for
assertions, which should be preferred moving forward.