### PR TITLE
Added FindBugs test filter

### DIFF
--- a/app/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/TopsoilMainWindowTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.app;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.fxml.JavaFXBuilderFactory;
 import javafx.scene.Scene;
 import javafx.scene.control.Tab;
@@ -47,8 +46,6 @@ import static org.testfx.api.FxAssert.verifyThat;
 public class TopsoilMainWindowTest extends ApplicationTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
-
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock

--- a/app/src/test/java/org/cirdles/topsoil/app/browse/DesktopWebBrowserTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/browse/DesktopWebBrowserTest.java
@@ -15,18 +15,21 @@
  */
 package org.cirdles.topsoil.app.browse;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.awt.Desktop;
-import java.io.IOException;
 import org.cirdles.topsoil.app.util.Alerter;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import static org.mockito.Mockito.*;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.awt.Desktop;
+import java.io.IOException;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -35,7 +38,6 @@ import org.mockito.junit.MockitoRule;
 public class DesktopWebBrowserTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock

--- a/app/src/test/java/org/cirdles/topsoil/app/builder/GuiceJavaFXBuilderFactoryTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/builder/GuiceJavaFXBuilderFactoryTest.java
@@ -18,7 +18,6 @@ package org.cirdles.topsoil.app.builder;
 import com.google.inject.Binding;
 import com.google.inject.Injector;
 import com.google.inject.Provider;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.util.BuilderFactory;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +37,6 @@ import static org.mockito.Mockito.when;
 public class GuiceJavaFXBuilderFactoryTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock

--- a/app/src/test/java/org/cirdles/topsoil/app/table/TsvTableSortPolicyTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/table/TsvTableSortPolicyTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.app.table;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -45,7 +44,6 @@ import static org.mockito.Mockito.when;
 public class TsvTableSortPolicyTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock

--- a/app/src/test/java/org/cirdles/topsoil/app/util/ApplicationDirectoryProviderTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/util/ApplicationDirectoryProviderTest.java
@@ -17,7 +17,6 @@ package org.cirdles.topsoil.app.util;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.cirdles.topsoil.app.metadata.ApplicationMetadata;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +38,6 @@ import static org.mockito.Mockito.when;
 public class ApplicationDirectoryProviderTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock

--- a/app/src/test/java/org/cirdles/topsoil/app/util/PlatformDependentProviderTest.java
+++ b/app/src/test/java/org/cirdles/topsoil/app/util/PlatformDependentProviderTest.java
@@ -49,7 +49,6 @@ public class PlatformDependentProviderTest {
     }
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public ExpectedException exception = ExpectedException.none();
 
     private final String osName;

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,16 @@ subprojects {
         toolVersion = '6.11.2'
     }
 
+    findbugsTest {
+        excludeFilterConfig = resources.text.fromString '''
+            <FindBugsFilter>
+                <Match>
+                    <Bug code="UrF"/>
+                </Match>
+            </FindBugsFilter>
+        '''
+    }
+
     task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
         from sourceSets.main.allSource

--- a/core/src/test/java/org/cirdles/topsoil/plot/JavaFXDisplayableTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/JavaFXDisplayableTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.plot;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.scene.layout.VBox;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +28,6 @@ import javax.swing.SwingUtilities;
 public class JavaFXDisplayableTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public Timeout timeout = Timeout.seconds(5);
 
     @Test

--- a/core/src/test/java/org/cirdles/topsoil/plot/standard/EvolutionPlotTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/standard/EvolutionPlotTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.plot.standard;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.cirdles.topsoil.plot.Plot;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class EvolutionPlotTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public Timeout timeout = Timeout.seconds(5);
 
     private Plot plot;

--- a/core/src/test/java/org/cirdles/topsoil/plot/standard/ScatterPlotTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/standard/ScatterPlotTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.plot.standard;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -42,7 +41,6 @@ import static org.cirdles.topsoil.plot.standard.ScatterPlotProperties.TITLE;
 public class ScatterPlotTest extends ApplicationTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public Timeout timeout = Timeout.seconds(5);
 
     private Plot plot;

--- a/core/src/test/java/org/cirdles/topsoil/plot/standard/UncertaintyEllipsePlotTest.java
+++ b/core/src/test/java/org/cirdles/topsoil/plot/standard/UncertaintyEllipsePlotTest.java
@@ -15,7 +15,6 @@
  */
 package org.cirdles.topsoil.plot.standard;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -34,7 +33,6 @@ import static org.cirdles.topsoil.plot.standard.UncertaintyEllipsePlotProperties
 public class UncertaintyEllipsePlotTest extends ApplicationTest {
 
     @Rule
-    @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public Timeout timeout = Timeout.seconds(5);
 
     private Plot plot;


### PR DESCRIPTION
Added a FindBugs filter to the test source set so that
`@SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")` is no
longer necessary for JUnit rules. Also removed existing instances of the
FindBugs suppress warnings annotation.