### PR TITLE
Fixed ellipse fill color bug

### DIFF
--- a/core/src/main/resources/org/cirdles/topsoil/plot/upb/uncertainty/UncertaintyEllipsePlot.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/upb/uncertainty/UncertaintyEllipsePlot.js
@@ -139,9 +139,12 @@
 
             var points = numeric.mul(
                     plot.getProperty("Uncertainty"),
-                    numeric.dot(controlPointsBase, r));
+                    numeric.dot(controlPointsBase, r))
+                    .map(shift(d.x, d.y));
+            
+            points.Selected = d.Selected;
 
-            return points.map(shift(d.x, d.y));
+            return points;
         });
 
         plot.update(data);


### PR DESCRIPTION
Fixed ellipse fill color bug caused by "Selected" property not being
copied during caching.