### PR TITLE
Fixe bug with initializing concordia tick labels

### DIFF
--- a/core/src/main/resources/org/cirdles/topsoil/plot/upb/uncertainty/UncertaintyEllipsePlot.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/upb/uncertainty/UncertaintyEllipsePlot.js
@@ -343,13 +343,15 @@
         var tickLabels;
         (tickLabels = plot.area.clipped.selectAll(".tickLabel")
                 .data(plot.t.ticks()))
-                .attr("x", function (t) { return x(wetherill.x(t)) + 12; })
-                .attr("y", function (t) { return y(wetherill.y(t)) + 5; })
-                .text(function (t) { return t / 1000000; })
                 .enter()
                 .append("text")
                 .attr("font-family", "sans-serif")
                 .attr("class", "tickLabel");
+        
+        tickLabels
+                .attr("x", function (t) { return x(wetherill.x(t)) + 12; })
+                .attr("y", function (t) { return y(wetherill.y(t)) + 5; })
+                .text(function (t) { return t / 1000000; });
 
         // update the ellipses
         ellipses.attr("d", function (d) {


### PR DESCRIPTION
Fixed uncertainty ellipse plot bug where concordia tick labels delayed displaying