### PR TITLE
updates core build.gradle with latest version of com.eriwen.gradle.js

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,6 @@
 // BEGIN JAVASCRIPT SUPPORT
 plugins {
-    id 'com.eriwen.gradle.js' version '1.12.1'
+    id "com.eriwen.gradle.js" version "2.14.1"
     id 'com.github.rundis.buster' version '0.2.4.2'
 }
 


### PR DESCRIPTION
version = 2.14.1.  The older version is no longer available - I detected that on a clean machine.

@ben-muldrow  please review and merge if advised.