### PR TITLE
Adds killPlot() to PlotInformation for finalization of plot objects

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/progress/menu/MenuItemEventHandler.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/menu/MenuItemEventHandler.java
@@ -39,6 +39,8 @@ import org.cirdles.topsoil.plot.Plot;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -350,13 +352,15 @@ public class MenuItemEventHandler {
                         ButtonType.YES);
                 plotOverwrite.showAndWait().ifPresent(response -> {
                             if (response == ButtonType.YES) {
-                                for (PlotInformation plotInfo : tabs.getSelectedTab()
-                                        .getTopsoilTable().getOpenPlots()) {
-                                    try {
-                                        ((JavaScriptPlot) plotInfo.getPlot()).finalize();
-                                    } catch (Throwable t) {
-                                        t.printStackTrace();
-                                    }
+                                Collection<PlotInformation> plots = tabs
+                                        .getSelectedTab().getTopsoilTable()
+                                        .getOpenPlots();
+                                TopsoilTable topsoilTable = tabs
+                                        .getSelectedTab()
+                                        .getTopsoilTable();
+                                for (PlotInformation plotInfo : plots) {
+                                    topsoilTable.removeOpenPlot(plotInfo
+                                            .getTopsoilPlotType());
                                 }
                                 stage.close();
                                 generateNewPlot(plotType, table);
@@ -384,8 +388,7 @@ public class MenuItemEventHandler {
                     Plot plot = plotType.getPlot();
 
                     plot.setData(data);
-                    Parent plotWindow = new PlotWindow(
-                            plot, plotType.getPropertiesPanel());
+                    Parent plotWindow = new PlotWindow(plot, plotType.getPropertiesPanel());
 
                     SimplePlotContext plotContext =
                             (SimplePlotContext)

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
@@ -292,6 +292,7 @@ public class TopsoilTable implements GenericTable {
     }
 
     public void removeOpenPlot(TopsoilPlotType plotType) {
+        this.openPlots.get(plotType.getName()).killPlot();
         this.openPlots.remove(plotType.getName());
     }
 }

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCell.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCell.java
@@ -74,7 +74,10 @@ public class TopsoilTableCell extends TableCell<TopsoilDataEntry, Double> {
     @Override
     public void cancelEdit() {
         super.cancelEdit();
-        this.setText(getItem().toString());
+        DecimalFormat df = new DecimalFormat();
+        df.setMinimumFractionDigits(9);
+        df.setMaximumFractionDigits(9);
+        this.setText(df.format(getItem()));
         this.setGraphic(null);
     }
 

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/PlotInformation.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/PlotInformation.java
@@ -3,6 +3,8 @@ package org.cirdles.topsoil.app.progress.util.serialization;
 import javafx.stage.Stage;
 import org.cirdles.topsoil.app.plot.VariableBinding;
 import org.cirdles.topsoil.app.progress.plot.TopsoilPlotType;
+import org.cirdles.topsoil.plot.BasePlot;
+import org.cirdles.topsoil.plot.JavaScriptPlot;
 import org.cirdles.topsoil.plot.Plot;
 
 import java.util.Collection;
@@ -110,5 +112,13 @@ public class PlotInformation {
      */
     public HashMap<String, String> getVariableBindingNames() {
         return this.variableBindings;
+    }
+
+    public void killPlot() {
+        try {
+            ((JavaScriptPlot) this.plot).killPlot();
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/SerializableTopsoilSession.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/SerializableTopsoilSession.java
@@ -211,8 +211,7 @@ class SerializableTopsoilSession implements Serializable {
         plot.setData(fieldData);
         plot.setProperties((Map<String, Object>) plotOptions.get("Properties"));
 
-        Parent plotWindow = new PlotWindow(
-                plot, plotType.getPropertiesPanel());
+        Parent plotWindow = new PlotWindow(plot, plotType.getPropertiesPanel());
 
         SimplePlotContext plotContext =
                 (SimplePlotContext)

--- a/core/src/main/java/org/cirdles/topsoil/plot/BasePlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/BasePlot.java
@@ -60,4 +60,7 @@ public abstract class BasePlot implements Plot {
         this.properties = properties;
     }
 
+    public void killPlot() throws Throwable {
+        super.finalize();
+    }
 }

--- a/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
@@ -290,9 +290,4 @@ public abstract class JavaScriptPlot extends BasePlot implements JavaFXDisplayab
             });
         }
     }
-
-    public void finalize() throws Throwable {
-        super.finalize();
-    }
-
 }


### PR DESCRIPTION
Restructures plot finalization to make a little more sense. One plot can be successfully shown at a time. 