### PR TITLE
Gets rid of errors in editing table cells.

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/progress/tab/TopsoilTab.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/tab/TopsoilTab.java
@@ -7,7 +7,6 @@ import javafx.scene.control.TextField;
 import org.cirdles.topsoil.app.progress.table.TopsoilTable;
 import org.cirdles.topsoil.app.progress.util.Command;
 import org.cirdles.topsoil.app.progress.util.UndoManager;
-import org.cirdles.topsoil.app.progress.util.serialization.PlotInformation;
 
 /**
  * A custom <tt>Tab</tt> which stores a <tt>TopsoilTable</tt>.

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
@@ -22,7 +22,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Created by benjaminmuldrow on 7/6/16.
+ * This is the core data model for a table. It contains the <tt>TableView</tt> used to display the data, as well as
+ * any information about open plots which reference this data model.
+ *
+ * @author benjaminmuldrow
+ *
+ * @see TableView
+ * @see TopsoilDataEntry
  */
 public class TopsoilTable implements GenericTable {
 
@@ -226,52 +232,32 @@ public class TopsoilTable implements GenericTable {
 
     }
 
-    @Override
-    public void deleteRow(int index) {
-        this.dataEntries[index].getProperties().remove(0, headers.length);
-    }
-
-    @Override
-    public void addRow() {
-        TopsoilDataEntry dataEntry = new TopsoilDataEntry();
-        for (String header : this.headers) {
-            dataEntry.addEntries(0.0);
-        }
-        this.table.getItems().add(dataEntry);
-    }
-
-    @Override
-    public void clear() {
-        this.getTable().getItems().clear();
-    }
-
-    @Override
-    public TableView getTable() {
-        return this.table;
-    }
-
+    /**
+     * Returns the <tt>IsotopeType</tt> of the current <tt>TopsoilTable</tt>.
+     *
+     * @return  the table's IsotopeType
+     */
     public IsotopeType getIsotopeType() {
         return this.isotopeType;
     }
 
+    /**
+     * Sets the <tt>IsotopeType</tt> of the current <tt>TopsoilTable</tt>.
+     *
+     * @param isotopeType   the new IsotopeType
+     */
     public void setIsotopeType(IsotopeType isotopeType) {
         this.isotopeType = isotopeType;
     }
 
-    @Override
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    @Override
-    public String [] getHeaders() {
-        return this.headers.clone();
-    }
-
+    /**
+     * Resets the string ids associated with each <tt>TableColumn</tt> in the <tt>TopsoilTable</tt>'s
+     * <tt>TableView</tt>.
+     * <p>Each TableColumn has an associated String id assigned to it, increasing numerically from 1, left to right.
+     * This is to keep track of the order of the columns before and after they are re-ordered due to clicking and
+     * dragging.
+     * </p>
+     */
     public void resetIds() {
         int id = 0;
         for (TableColumn<TopsoilDataEntry, ?> column : this.table.getColumns()) {
@@ -280,6 +266,12 @@ public class TopsoilTable implements GenericTable {
         }
     }
 
+    /**
+     * Returns true if the <tt>TableView</tt> is empty. In this case, "empty" means that it has one data entry filled
+     * with 0.0s.
+     *
+     * @return  true or false
+     */
     public boolean isCleared() {
         boolean rtnval = true;
         if (table.getItems().size() != 1) {
@@ -294,15 +286,76 @@ public class TopsoilTable implements GenericTable {
         return rtnval;
     }
 
+    /**
+     * Returns a Collection of <tt>PlotInformation</tt>, each containing information on an open plot associated with
+     * this data table.
+     *
+     * @return  a Collection of PlotInformation objects
+     */
     public Collection<PlotInformation> getOpenPlots() {
         return this.openPlots.values();
     }
 
+    /**
+     * Adds information about an open plot to this data table.
+     *
+     * @param plotInfo  a new PlotInformation
+     */
     public void addOpenPlot(PlotInformation plotInfo) {
         this.openPlots.put(plotInfo.getTopsoilPlotType().getName(), plotInfo);
     }
 
+    /**
+     * Removes information about an open plot to this data table (typically once the table has been closed).
+     *
+     * @param plotType  the TopsoilPlotType of the plot to be removed
+     */
     public void removeOpenPlot(TopsoilPlotType plotType) {
         this.openPlots.remove(plotType.getName());
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deleteRow(int index) {
+        this.dataEntries[index].getProperties().remove(0, headers.length);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void addRow() {
+        TopsoilDataEntry dataEntry = new TopsoilDataEntry();
+        for (String header : this.headers) {
+            dataEntry.addEntries(0.0);
+        }
+        this.table.getItems().add(dataEntry);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clear() {
+        this.getTable().getItems().clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public TableView getTable() {
+        return this.table;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String [] getHeaders() {
+        return this.headers.clone();
+    }
+
 }

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTable.java
@@ -6,7 +6,6 @@ import javafx.collections.ListChangeListener;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.input.KeyCode;
-import javafx.scene.text.Font;
 import org.cirdles.topsoil.app.dataset.field.Field;
 import org.cirdles.topsoil.app.dataset.field.NumberField;
 import org.cirdles.topsoil.app.progress.isotope.IsotopeType;
@@ -41,7 +40,7 @@ public class TopsoilTable implements GenericTable {
         // initialize table
         this.table = new TableView<>();
         this.table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
-        TableView.TableViewSelectionModel selectionModel = this.table.getSelectionModel();
+        TableView.TableViewSelectionModel<TopsoilDataEntry> selectionModel = this.table.getSelectionModel();
         selectionModel.setCellSelectionEnabled(true);
         this.dataEntries = dataEntries;
         this.table.setEditable(true);
@@ -91,9 +90,21 @@ public class TopsoilTable implements GenericTable {
             // Shift + Tab focuses left cell
             if (keyevent.getCode().equals(KeyCode.TAB)) {
                 if (keyevent.isShiftDown()) {
-                    selectionModel.selectLeftCell();
+                    if (selectionModel.getSelectedCells().get(0).getColumn() == 0 &&
+                            selectionModel.getSelectedIndex() != 0) {
+                        selectionModel.select(selectionModel.getSelectedIndex() - 1, this.table.getColumns().get
+                                (this.getHeaders().length - 1));
+                    } else {
+                        selectionModel.selectLeftCell();
+                    }
                 } else {
-                    selectionModel.selectRightCell();
+                    if (selectionModel.getSelectedCells().get(0).getColumn() ==
+                        this.getHeaders().length - 1 && selectionModel.getSelectedIndex() !=
+                                                        this.table.getItems().size() - 1) {
+                        selectionModel.select(selectionModel.getSelectedIndex() + 1, this.table.getColumns().get(0));
+                    } else {
+                        selectionModel.selectRightCell();
+                    }
                 }
 
                 keyevent.consume();

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCellContextMenu.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCellContextMenu.java
@@ -7,6 +7,7 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import org.cirdles.topsoil.app.progress.tab.TopsoilTabPane;
+import org.cirdles.topsoil.app.progress.table.TopsoilTableCell;
 
 /**
  * Created by benjaminmuldrow on 8/1/16.

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCommands.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/table/TopsoilTableCommands.java
@@ -19,7 +19,7 @@ import java.util.ArrayDeque;
  * @see org.cirdles.topsoil.app.progress.util.Command
  * @see org.cirdles.topsoil.app.progress.util.UndoManager
  */
-class TopsoilTableCellEditCommand implements Command {
+class TableCellEditCommand implements Command {
 
     private TopsoilTableCell cell;
     private TopsoilDataEntry row;
@@ -34,7 +34,7 @@ class TopsoilTableCellEditCommand implements Command {
      * @param formerValue   the former Double value of the cell
      * @param newValue  the new Double value of the cell
      */
-    TopsoilTableCellEditCommand(TopsoilTableCell cell, Double formerValue,
+    TableCellEditCommand(TopsoilTableCell cell, Double formerValue,
                                 Double newValue) {
         this.cell = cell;
         this.row = cell.getDataEntry();
@@ -64,10 +64,9 @@ class TopsoilTableCellEditCommand implements Command {
      */
     private void changeCellValue(Double value) {
 
-        this.row.changeEntry(cell.getColumnIndex(),
-                new SimpleDoubleProperty(value));
-        this.cell.updateItem(this.row.getProperties()
-                .get(cell.getColumnIndex()).doubleValue(), false);
+        this.row.changeEntry(cell.getColumnIndex(), new SimpleDoubleProperty(value));
+        this.cell.getTableColumn().setVisible(false);
+        this.cell.getTableColumn().setVisible(true);
     }
 
     /**
@@ -83,10 +82,6 @@ class TopsoilTableCellEditCommand implements Command {
 
 /**
  * An undoable <tt>Command</tt> instance that can be added to a TopsoilTab's
-<<<<<<< 2d8c47facf09f00aa4dfd81986045897e8876203
-<<<<<<< 0a4c770e711478c8c9773b6fb6a771f6e0c5b89e
-=======
->>>>>>> Add undo commands for button bar.
  * <tt>UndoManager</tt> when a row is inserted into the <tt>TableView</tt>.
  * This class creates an empty <tt>TopsoilDataEntry</tt> and inserts is above
  * the selected row.
@@ -138,11 +133,6 @@ class InsertRowCommand implements Command {
 
 /**
  * An undoable <tt>Command</tt> instance that can be added to a TopsoilTab's
-<<<<<<< 2d8c47facf09f00aa4dfd81986045897e8876203
-=======
->>>>>>> Implement undo/redo for TableView with Command Pattern
-=======
->>>>>>> Add undo commands for button bar.
  * <tt>UndoManager</tt> when a row is deleted in the <tt>TableView</tt>. This
  * class stores the <tt>TopsoilDataEntry</tt> that was deleted and the index
  * of the <tt>TableView</tt> from which it was deleted.
@@ -155,7 +145,7 @@ class DeleteRowCommand implements Command {
 
     private int index;
     private TopsoilDataEntry dataEntry;
-    private TableView tableView;
+    private TableView<TopsoilDataEntry> tableView;
 
     /**
      * Constructs a new delete row command. Gets the row, its index, and the
@@ -207,14 +197,14 @@ class DeleteRowCommand implements Command {
  */
 class NewRowCommand implements Command {
 
-    private TableView tableView;
+    private TableView<TopsoilDataEntry> tableView;
 
     /**
      * Constructs a new new row command for the specified table view.
      *
      * @param tableView the TableView in question
      */
-    NewRowCommand(TableView tableView) {
+    NewRowCommand(TableView<TopsoilDataEntry> tableView) {
         this.tableView = tableView;
     }
 
@@ -286,10 +276,8 @@ class ClearRowCommand implements Command {
      */
     public void undo() {
         TopsoilDataEntry dataEntry = new TopsoilDataEntry();
-        int i = 0;
-        for (Object column : this.tableView.getColumns()) {
+        for (int i = 0; i < this.tableView.getColumns().size(); i++) {
             dataEntry.addEntries(this.row.getProperties().get(i).getValue());
-            i++;
         }
         this.tableView.getItems().remove(index);
         this.tableView.getItems().add(index, dataEntry);
@@ -318,7 +306,7 @@ class ClearRowCommand implements Command {
  */
 class DeleteColumnCommand implements Command {
 
-    private TableView tableView;
+    private TableView<TopsoilDataEntry> tableView;
     private TableColumn<TopsoilDataEntry, Double> column;
     private int index;
 
@@ -402,7 +390,6 @@ class ClearColumnCommand implements Command {
         this.column.setVisible(true);
     }
 
-    // TODO unknown bug breaks table on undo
     /**
      * Called to undo the column deletion.
      */
@@ -427,21 +414,9 @@ class ClearColumnCommand implements Command {
 
 /**
  * An undoable <tt>Command</tt> instance that can be added to a TopsoilTab's
-<<<<<<< 2d8c47facf09f00aa4dfd81986045897e8876203
-<<<<<<< 0a4c770e711478c8c9773b6fb6a771f6e0c5b89e
  * <tt>UndoManager</tt> when a <tt>TopsoilTableCell</tt> in the
  * <tt>TableView</tt> is cleared. This class stores the cell, the row it
  * belongs to, and the former value of the cell.
-=======
- * <tt>UndoManager</tt> when a <tt>TopsoilTableCell</tt> in the <tt>TableView</tt>
- * is cleared. This class stores the cell, the row it belongs to, and the former
- * value of the cell.
->>>>>>> Implement undo/redo for TableView with Command Pattern
-=======
- * <tt>UndoManager</tt> when a <tt>TopsoilTableCell</tt> in the
- * <tt>TableView</tt> is cleared. This class stores the cell, the row it
- * belongs to, and the former value of the cell.
->>>>>>> Add undo commands for button bar.
  *
  * @author marottajb
  * @see Command
@@ -486,10 +461,9 @@ class ClearCellCommand implements Command {
      * @param value the Double value to assign
      */
     private void changeCellValue(Double value) {
-        this.row.changeEntry(this.cell.getColumnIndex(),
-                new SimpleDoubleProperty(value));
-        this.cell.updateItem(this.row.getProperties()
-                .get(this.cell.getColumnIndex()).doubleValue(), false);
+        this.row.changeEntry(this.cell.getColumnIndex(), new SimpleDoubleProperty(value));
+        this.cell.getTableColumn().setVisible(false);
+        this.cell.getTableColumn().setVisible(true);
     }
 
     /**

--- a/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/SerializableTopsoilSession.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/progress/util/serialization/SerializableTopsoilSession.java
@@ -20,8 +20,6 @@ import org.cirdles.topsoil.app.progress.table.TopsoilTable;
 import org.cirdles.topsoil.plot.Plot;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectStreamClass;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;


### PR DESCRIPTION
Limits inconsistencies when editing TableCell values. A new value must be committed by pressing the Enter key.

* Due to an issue in JavaFX, it is not possible to commit when a TableCell loses focus while also maintaining that a new value is committed when pressing Enter. It is a known issue slated for a fix in Java 9.