### PR TITLE
Makes "empty" tables have one row of 0.0s

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/menu/MenuItemEventHandler.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/menu/MenuItemEventHandler.java
@@ -193,9 +193,6 @@ public class MenuItemEventHandler {
         TopsoilDataTable table = null;
         UncertaintyFormat format;
 
-        //TODO Determine format of table.
-        format = UncertaintyFormat.TWO_SIGMA_PERCENT;
-
         if (isotopeType != null) {
                 
                 List<TopsoilDataEntry> entries = null;
@@ -208,6 +205,21 @@ public class MenuItemEventHandler {
                 if (entries == null) {
                         table = null;
                     } else {
+                    
+                        switch (isotopeType) {
+                            case Generic:
+                                format = UncertaintyFormat.TWO_SIGMA_PERCENT;
+                                break;
+                            case UPb:
+                                format = UncertaintyFormat.TWO_SIGMA_PERCENT;
+                                break;
+                            case UTh:
+                                format = UncertaintyFormat.TWO_SIGMA_ABSOLUTE;
+                                break;
+                            default:
+                                format = UncertaintyFormat.TWO_SIGMA_PERCENT;
+                        }
+
                         ObservableList<TopsoilDataEntry> data = FXCollections.observableList(entries);
                         applyUncertaintyFormat(format, data);
 

--- a/app/src/main/java/org/cirdles/topsoil/app/tab/TopsoilTabContent.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/tab/TopsoilTabContent.java
@@ -58,16 +58,6 @@ public class TopsoilTabContent extends SplitPane {
     @FXML private TableView<TopsoilDataEntry> tableView;
 
     /**
-     * A {@code Button} that, when pressed, adds an empty row at the end of the {@code TableView}.
-     */
-    @FXML private Button addRowButton;
-
-    /**
-     * A {@code Button} that, when pressed, removes a row at the end of the {@code TableView}.
-     */
-    @FXML private Button removeRowButton;
-
-    /**
      * An {@code AnchorPane} that contains the {@link PlotPropertiesPanelController} for this tab.
      */
     @FXML private AnchorPane plotPropertiesAnchorPane;
@@ -103,20 +93,6 @@ public class TopsoilTabContent extends SplitPane {
 
         // Enables multiple cell selection.
 //        tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-
-        // Set initial state of remove button.
-
-        tableView.itemsProperty().addListener(c -> {
-            if (tableView.getItems() != null) {
-                tableView.getItems().addListener((ListChangeListener<TopsoilDataEntry>) d -> {
-                    if (tableView.getItems().isEmpty()) {
-                        removeRowButton.setDisable(true);
-                    } else {
-                        removeRowButton.setDisable(false);
-                    }
-                });
-            }
-        });
 
         configureColumns();
         resetIds();
@@ -273,30 +249,6 @@ public class TopsoilTabContent extends SplitPane {
         for (TableColumn<TopsoilDataEntry, ?> column : this.tableView.getColumns()) {
             column.setId(Integer.toString(id));
             id++;
-        }
-    }
-
-    /**
-     * Appends an empty {@code TopsoilDataEntry} to the end of the {@code TableView}.
-     */
-    @FXML private void addRowButtonAction() {
-        if (tableView.getItems() != null) {
-            InsertRowCommand insertRowCommand = new InsertRowCommand(tableView);
-            insertRowCommand.execute();
-            ((TopsoilTabPane) this.tableView.getScene().lookup("#TopsoilTabPane")).getSelectedTab().addUndo
-                    (insertRowCommand);
-        }
-    }
-
-    /**
-     * Removes a {@code TopsoilDataEntry} from the end of the {@code TableView}.
-     */
-    @FXML private void removeRowButtonAction() {
-        if (tableView.getItems() != null && !tableView.getItems().isEmpty()) {
-            DeleteRowCommand deleteRowCommand = new DeleteRowCommand(tableView);
-            deleteRowCommand.execute();
-            ((TopsoilTabPane) this.tableView.getScene().lookup("#TopsoilTabPane")).getSelectedTab().addUndo
-                    (deleteRowCommand);
         }
     }
 

--- a/app/src/main/java/org/cirdles/topsoil/app/table/TopsoilDataTable.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/table/TopsoilDataTable.java
@@ -114,7 +114,7 @@ public class TopsoilDataTable {
      */
     public TopsoilDataTable(String[] columnNames, IsotopeType isotopeType, UncertaintyFormat format,
                             TopsoilDataEntry... rows) {
-        this.numRows = rows.length;
+        this.numRows = rows.length == 0 ? 1 : rows.length;
         this.isotopeType = new SimpleObjectProperty<>(isotopeType);
         this.uncertaintyFormat = format;
         this.columnForVariable = new HashMap<>();
@@ -354,14 +354,26 @@ public class TopsoilDataTable {
 
         ObservableList<TopsoilDataColumn> dataColumns = FXCollections.observableArrayList();
 
-        // TODO Read in any number of columns.
-//        for (int colIndex = 0; colIndex < rows[0].getProperties().size(); colIndex++) {
-        for (int colIndex = 0; colIndex < 5; colIndex++) {
-            TopsoilDataColumn dataColumn = new TopsoilDataColumn();
-            for (TopsoilDataEntry row : rows) {
-                dataColumn.add(row.getProperties().get(colIndex));
+        if (rows.length <= 0) {
+            // TODO Read in any number of columns.
+            for (int colIndex = 0; colIndex < 5; colIndex++) {
+                TopsoilDataColumn dataColumn = new TopsoilDataColumn();
+                    dataColumn.add(new SimpleDoubleProperty(0.0));
+                dataColumns.add(dataColumn);
             }
-            dataColumns.add(dataColumn);
+        } else {
+            // TODO Read in any number of columns.
+            for (int colIndex = 0; colIndex < 5; colIndex++) {
+                TopsoilDataColumn dataColumn = new TopsoilDataColumn();
+                for (TopsoilDataEntry row : rows) {
+                    if (row.getProperties().size() <= colIndex) {
+                        dataColumn.add(new SimpleDoubleProperty(0.0));
+                    } else {
+                        dataColumn.add(row.getProperties().get(colIndex));
+                    }
+                }
+                dataColumns.add(dataColumn);
+            }
         }
 
         return dataColumns;
@@ -377,14 +389,26 @@ public class TopsoilDataTable {
 
         ObservableList<TopsoilDataColumn> dataColumns = FXCollections.observableArrayList();
 
-        // TODO Read in any number of columns.
-//        for (int colIndex = 0; colIndex < rows[0].length; colIndex++) {
-        for (int colIndex = 0; colIndex < 5; colIndex++) {
-            TopsoilDataColumn dataColumn = new TopsoilDataColumn();
-            for (Double[] row : rows) {
-                dataColumn.add(new SimpleDoubleProperty(row[colIndex]));
+        if (rows.length <= 0) {
+            // TODO Read in any number of columns.
+            for (int colIndex = 0; colIndex < 5; colIndex++) {
+                TopsoilDataColumn dataColumn = new TopsoilDataColumn();
+                dataColumn.add(new SimpleDoubleProperty(0.0));
+                dataColumns.add(dataColumn);
             }
-            dataColumns.add(dataColumn);
+        } else {
+            // TODO Read in any number of columns.
+            for (int colIndex = 0; colIndex < 5; colIndex++) {
+                TopsoilDataColumn dataColumn = new TopsoilDataColumn();
+                for (Double[] row : rows) {
+                    if (row.length <= colIndex) {
+                        dataColumn.add(new SimpleDoubleProperty(0.0));
+                    } else {
+                        dataColumn.add(new SimpleDoubleProperty(row[colIndex]));
+                    }
+                }
+                dataColumns.add(dataColumn);
+            }
         }
 
         return dataColumns;
@@ -407,7 +431,16 @@ public class TopsoilDataTable {
      * @return  true or false
      */
     public boolean isCleared() {
-        return columnForVariable.get(Variables.X).isEmpty();
+
+        if (numRows == 1) {
+            for (int i = 0; i < dataColumns.size(); i++) {
+                if (Double.compare(dataColumns.get(i).get(0).get(), 0.0) != 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/app/src/main/java/org/cirdles/topsoil/app/table/TopsoilTableCellContextMenu.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/table/TopsoilTableCellContextMenu.java
@@ -106,6 +106,16 @@ class TopsoilTableCellContextMenu extends ContextMenu {
 //        copyCellItem = new MenuItem("Copy Cell");
 //        clearCellItem = new MenuItem("Clear Cell");
 
+        this.setOnShown(event -> {
+            if (((TopsoilTabPane) this.cell.getScene().lookup("#TopsoilTabPane")).getSelectedTab()
+                                                                                 .getTableController().getTable()
+                                                                                 .isCleared()) {
+                deleteRowItem.setDisable(true);
+            } else {
+                deleteRowItem.setDisable(false);
+            }
+        });
+
         //********************//
         //    ROW ACTIONS     //
         //********************//

--- a/app/src/main/java/org/cirdles/topsoil/app/table/command/DeleteRowCommand.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/table/command/DeleteRowCommand.java
@@ -3,6 +3,7 @@ package org.cirdles.topsoil.app.table.command;
 import javafx.scene.control.TableView;
 import org.cirdles.topsoil.app.dataset.entry.TopsoilDataEntry;
 import org.cirdles.topsoil.app.tab.TopsoilTab;
+import org.cirdles.topsoil.app.tab.TopsoilTabPane;
 import org.cirdles.topsoil.app.table.TopsoilTableCell;
 import org.cirdles.topsoil.app.util.undo.Command;
 import org.cirdles.topsoil.app.util.undo.UndoManager;
@@ -73,14 +74,24 @@ public class DeleteRowCommand implements Command {
      * Called to execute the row deletion.
      */
     public void execute() {
-        this.tableView.getItems().remove(index);
+        if (index == 0 && tableView.getItems().size() <= 1) {
+            tableView.getItems().remove(index);
+            tableView.getItems().add(TopsoilDataEntry.newEmptyDataEntry(tableView));
+        } else {
+            tableView.getItems().remove(index);
+        }
     }
 
     /**
      * Called to undo the row deletion.
      */
     public void undo() {
-        this.tableView.getItems().add(index, dataEntry);
+        if (((TopsoilTabPane) tableView.getScene().lookup("#TopsoilTabPane")).getSelectedTab().getTableController()
+                .getTable().isCleared()) {
+            tableView.getItems().remove(0);
+        }
+        tableView.getItems().add(index, dataEntry);
+
     }
 
     /** {@inheritDoc}

--- a/app/src/main/resources/org/cirdles/topsoil/app/tab/topsoil-tab-content.fxml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/tab/topsoil-tab-content.fxml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.*?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
@@ -14,7 +19,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<SplitPane dividerPositions="0.6" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.cirdles.topsoil.app.tab.TopsoilTabContent">
+<SplitPane dividerPositions="0.6" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.cirdles.topsoil.app.tab.TopsoilTabContent">
    <items>
       <AnchorPane>
          <children>
@@ -80,32 +85,9 @@
                               <TableColumn prefWidth="75.0" sortable="false" text="CorrCoef Column" />
                            </columns>
                         </TableView>
-                        <HBox alignment="CENTER">
-                           <children>
-                              <Button fx:id="addRowButton" alignment="CENTER" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#addRowButtonAction" prefHeight="32.0" prefWidth="120.0" style="fx-border-radius: 50%;" text="Append Row">
-                                 <font>
-                                    <Font name="Lucida Sans Regular" size="12.0" />
-                                 </font>
-                                 <VBox.margin>
-                                    <Insets bottom="9.0" top="9.0" />
-                                 </VBox.margin>
-                                 <HBox.margin>
-                                    <Insets bottom="9.0" left="9.0" right="9.0" top="9.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <Button fx:id="removeRowButton" alignment="CENTER" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#removeRowButtonAction" prefHeight="32.0" prefWidth="120.0" style="fx-border-radius: 50%;" text="Remove Last Row">
-                                 <font>
-                                    <Font name="Lucida Sans Regular" size="12.0" />
-                                 </font>
-                                 <HBox.margin>
-                                    <Insets bottom="9.0" left="9.0" right="9.0" top="9.0" />
-                                 </HBox.margin>
-                              </Button>
-                           </children>
-                        </HBox>
                      </children>
                      <padding>
-                        <Insets left="10.0" right="10.0" />
+                        <Insets bottom="10.0" left="10.0" right="10.0" />
                      </padding>
                   </VBox>
                </children>


### PR DESCRIPTION
- Empty tables will have one row of 0.0s, so that the user is able to click on a cell to show the TopsoilTableCellContextMenu.
- The "Append Row" and "Remove Last Row" buttons have been removed.
- Fixes the loading process for UTh sample data; uncertainty format was 2-sigma percent when it should have been 2-sigma absolute.