### PR TITLE
Fixes small issues in plots

### DIFF
--- a/#.profile#
+++ b/#.profile#
@@ -1,0 +1,2 @@
+JAVA_HOME=/Library/Java/Home
+export JAVA_HOME;

--- a/app/src/main/java/org/cirdles/topsoil/app/plot/PlotGenerationHandler.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/plot/PlotGenerationHandler.java
@@ -100,6 +100,7 @@ public class PlotGenerationHandler {
         });
 
         plotStage.setOnCloseRequest(closeEvent -> {
+            plot.stop();
             tableController.getTable().removeOpenPlot(plotType);
             propertiesPanel.removePlot();
         });

--- a/core/src/main/java/org/cirdles/topsoil/plot/Displayable.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/Displayable.java
@@ -19,6 +19,7 @@ import javafx.scene.Node;
 import org.w3c.dom.Document;
 
 import javax.swing.JComponent;
+import java.io.File;
 
 /**
  * An interface for objects that are displayable in a couple of common formats.
@@ -55,9 +56,9 @@ public interface Displayable {
     }
 
     /**
-     * Saves a {@code Document} representing this {@code Displayable}.
+     * Saves a {@code Document} representing this {@code Displayable} to the specified {@code File}.
      */
-    default void saveAsSVGDocument() {
+    default void saveAsSVGDocument(File file) {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
@@ -70,6 +70,11 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
 
     private static final String HTML_TEMPLATE;
 
+    // When loaded into the WebEngine, it seems to significantly decrease the time it takes for the WebEngine to stop
+    // running JavaScript. The message itself is inconsequential.
+    private static final String HALT_MESSAGE = "This message will be loaded into the WebEngine to attempt to stop it " +
+                                               "from running JavaScript.";
+
     static {
         final ResourceExtractor RESOURCE_EXTRACTOR
                 = new ResourceExtractor(JavaScriptPlot.class);
@@ -252,7 +257,13 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
 
             webEngine.getLoadWorker().stateProperty().addListener(
                     (observable, oldValue, newValue) -> {
-                        if (newValue == SUCCEEDED) {
+
+                        if (webEngine.getDocument() != null &&
+                            webEngine.getDocument().getDoctype() != null &&
+                            newValue == SUCCEEDED) {
+
+                            System.out.println("LOADING TOPSOIL");
+
                             if (new IsBlankImage().test(screenCapture())) {
                                 webEngine.loadContent(buildContent());
                             }
@@ -269,6 +280,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
                             }
 
                             loadFuture.complete(null);
+
                         }
                     });
 
@@ -366,8 +378,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
     }
 
     @Override
-    public void cancelFXApplicationThread() {
-        PlatformImpl.tkExit();
-        Platform.exit();
+    public void stop() {
+        getWebEngine().loadContent(HALT_MESSAGE);
     }
 }

--- a/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
@@ -45,6 +45,7 @@ import java.awt.AWTException;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -321,9 +322,9 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
         return svgDocument;
     }
 
-    @Override
-    public void saveAsSVGDocument() {
-        new SVGSaver().save(displayAsSVGDocument());
+    /**{@inheritDoc}*/
+    public void saveAsSVGDocument(File file) {
+        new SVGSaver().save(displayAsSVGDocument(), file);
     }
 
     /**{@inheritDoc}*/

--- a/core/src/main/java/org/cirdles/topsoil/plot/Plot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/Plot.java
@@ -17,6 +17,7 @@ package org.cirdles.topsoil.plot;
 
 import java.util.List;
 import java.util.Map;
+import javafx.scene.web.WebEngine;
 
 /**
  * A generalized plot that can express itself as a {@link javafx.scene.Node}.
@@ -66,6 +67,9 @@ public interface Plot extends Displayable {
      */
     void recenter();
 
-    void cancelFXApplicationThread();
+    /**
+     * Attempts to stop the {@code Plot}'s {@link WebEngine} running JavaScript content.
+     */
+    void stop();
 
 }

--- a/core/src/main/java/org/cirdles/topsoil/plot/internal/SVGSaver.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/internal/SVGSaver.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import static javax.xml.transform.OutputKeys.DOCTYPE_PUBLIC;
@@ -77,6 +78,20 @@ public class SVGSaver {
                 LOGGER.error(null, ex);
             }
         });
+    }
+
+    /**
+     * Saves the vector image in Topsoil with the .svg file extension, to the provided file.
+     * <p>
+     * Note: Use this method if the project is in Swing, because it doesn't require the use of the JavaFX FileChooser.
+     */
+    public void save(Document svgDocument, File file) {
+        try {
+            writeSVGToOutputStream(svgDocument, new FileOutputStream(file));
+        } catch (IOException e) {
+            LOGGER.error(null, e);
+            e.printStackTrace();
+        }
     }
 
     /**


### PR DESCRIPTION
- Requires a File as a parameter for Displayable.saveAsSVGDocument(). This way, when using the Topsoil library within a Swing application, the method doesn't have to depend on the JavaFX FileChooser.
- Fixes a misplaced line in topsoil.js that was causing problems with the alignment of the plot.
- Adds a Plot.stop() method that significantly decreases the amount of time required for the WebEngine to stop running JavaScript. It just loads a String message via WebEngine.loadContent().