### PR TITLE
Draw McLean Regression line

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/plot/PlotPropertiesPanelController.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/plot/PlotPropertiesPanelController.java
@@ -127,6 +127,12 @@ public class PlotPropertiesPanelController {
     @FXML private CheckBox evolutionCheckBox;
 
     /**
+     * An {@code HBox} containing the controls for the regression line feature.
+     */
+    @FXML private HBox regressionFeature;
+    @FXML private CheckBox regressionCheckBox;
+
+    /**
      * A {@code Button} that, when pressed, generates a {@link Plot} with the current options for the current table.
      */
     @FXML private Button generatePlotButton;
@@ -177,7 +183,7 @@ public class PlotPropertiesPanelController {
     public final ObjectProperty<IsotopeType> isotopeTypeObjectProperty() {
         if (isotopeType == null) {
             isotopeType = new SimpleObjectProperty<>(STRING_TO_ISOTOPE_TYPE.get(isotopeSystemChoiceBox
-                                                                                        .getSelectionModel().getSelectedItem()));
+                    .getSelectionModel().getSelectedItem()));
 
             isotopeType.addListener(c -> {
                 if (STRING_TO_ISOTOPE_TYPE.get(isotopeSystemChoiceBox.getSelectionModel().getSelectedItem()) != isotopeType.get()) {
@@ -193,18 +199,22 @@ public class PlotPropertiesPanelController {
                     case Generic:
                         concordiaCheckBox.setDisable(true);
                         evolutionCheckBox.setDisable(true);
+                        regressionCheckBox.setDisable(false);
                         break;
                     case UPb:
                         concordiaCheckBox.setDisable(false);
                         evolutionCheckBox.setDisable(true);
+                        regressionCheckBox.setDisable(false);
                         break;
                     case UTh:
                         concordiaCheckBox.setDisable(true);
                         evolutionCheckBox.setDisable(false);
+                        regressionCheckBox.setDisable(true);
                         break;
                     default:
                         concordiaCheckBox.setDisable(true);
                         evolutionCheckBox.setDisable(true);
+                        regressionCheckBox.setDisable(false);
                         break;
                 }
             });
@@ -225,7 +235,7 @@ public class PlotPropertiesPanelController {
     public final ObjectProperty<UncertaintyFormat> uncertaintyProperty() {
         if (uncertainty == null) {
             uncertainty = new SimpleObjectProperty<>(STRING_TO_UNCERTAINTY_FORMAT.get(uncertaintyChoiceBox
-                                                                                         .getSelectionModel().getSelectedItem()));
+                    .getSelectionModel().getSelectedItem()));
 
             uncertainty.addListener(c-> {
                 if (STRING_TO_UNCERTAINTY_FORMAT.get(uncertaintyChoiceBox.getSelectionModel().getSelectedItem()) != uncertainty.get()) {
@@ -512,6 +522,24 @@ public class PlotPropertiesPanelController {
         evolutionCheckBox.setSelected(b);
     }
 
+    /**
+     * A {@code BooleanProperty} tracking whether or not a regression line should be drawn in the plot.
+     */
+    private BooleanProperty showRegressionLine;
+    public final BooleanProperty showRegressionLineProperty() {
+        if (showRegressionLine == null) {
+            showRegressionLine = new SimpleBooleanProperty(regressionCheckBox.isSelected());
+            showRegressionLine.bind(regressionCheckBox.selectedProperty());
+        }
+        return showRegressionLine;
+    }
+    public Boolean shouldShowRegressionLine() {
+        return showRegressionLineProperty().get();
+    }
+    public void setShowRegressionLine(Boolean b) {
+        regressionCheckBox.setSelected(b);
+    }
+
     //***********************
     // Methods
     //***********************
@@ -578,6 +606,8 @@ public class PlotPropertiesPanelController {
 
         evolutionCheckBox.setSelected((Boolean) PROPERTIES.get(EVOLUTION_MATRIX));
 
+        regressionCheckBox.setSelected((Boolean) PROPERTIES.get(REGRESSION_LINE));
+
         // Automatically adjust PROPERTIES
         isotopeTypeObjectProperty().addListener(c -> {
             PROPERTIES.put(ISOTOPE_TYPE, isotopeTypeObjectProperty().get().getName());
@@ -585,9 +615,9 @@ public class PlotPropertiesPanelController {
         });
         isotopeSystemChoiceBox.getSelectionModel().selectedItemProperty().addListener(c -> {
             if (getIsotopeType() != STRING_TO_ISOTOPE_TYPE.get(isotopeSystemChoiceBox.getSelectionModel()
-                                                                                     .getSelectedItem())) {
+                    .getSelectedItem())) {
                 isotopeTypeObjectProperty().set(STRING_TO_ISOTOPE_TYPE.get(isotopeSystemChoiceBox.getSelectionModel()
-                                                                                            .getSelectedItem()));
+                        .getSelectedItem()));
             }
         });
 
@@ -664,6 +694,10 @@ public class PlotPropertiesPanelController {
         });
         showEvolutionMatrixProperty().addListener(c -> {
             PROPERTIES.put(EVOLUTION_MATRIX, shouldShowEvolutionMatrix());
+            updateProperties();
+        });
+        showRegressionLineProperty().addListener(x -> {
+            PROPERTIES.put(REGRESSION_LINE, shouldShowRegressionLine());
             updateProperties();
         });
     }
@@ -760,6 +794,7 @@ public class PlotPropertiesPanelController {
                 (Double) plotProperties.get(UNCERTAINTY)));
         if (plotProperties.containsKey(CONCORDIA_LINE)) setShowConcordia((Boolean) plotProperties.get(CONCORDIA_LINE));
         if (plotProperties.containsKey(EVOLUTION_MATRIX)) setShowEvolutionMatrix((Boolean) plotProperties.get(EVOLUTION_MATRIX));
+        if (plotProperties.containsKey(REGRESSION_LINE)) setShowRegressionLine((Boolean) plotProperties.get(REGRESSION_LINE));
     }
 
     @FXML private void assignVariablesButtonAction() {

--- a/app/src/main/resources/org/cirdles/topsoil/app/tab/plot-properties-panel.fxml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/tab/plot-properties-panel.fxml
@@ -212,6 +212,15 @@
                                              </children>
                                           </HBox>
                                        </children>
+                                       <HBox fx:id="regressionFeature" alignment="CENTER_LEFT" minHeight="-Infinity" prefHeight="30.0">
+                                          <children>
+                                             <CheckBox fx:id="regressionCheckBox" mnemonicParsing="false" text="Regression Line">
+                                                <HBox.margin>
+                                                   <Insets left="10.0" right="10.0" />
+                                                </HBox.margin>
+                                             </CheckBox>
+                                          </children>
+                                       </HBox>
                                     </VBox>
                                  </children>
                                  <VBox.margin>

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ subprojects {
         compile 'ch.qos.logback:logback-classic:1.1.3'
         compile 'com.github.johnzeringue:extendsfx:v1.0.0-alpha.2'
         compile 'com.github.cirdles:commons:0f628cc'
+        compile 'com.github.cirdles.McLeanRegression:api:-SNAPSHOT'
+        compile "org.apache.commons:commons-math3:3.6.1"
         compile 'org.controlsfx:controlsfx:8.20.9'
 
         testCompile 'com.google.code.findbugs:annotations:3.0.0'

--- a/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/JavaScriptPlot.java
@@ -121,6 +121,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
     private WebView webView;
     private JSObject topsoil;
     private final JavaScriptBridge bridge = new JavaScriptBridge();
+    private final Regression regression = new Regression();
 
     /**
      * Creates a new {@link JavaScriptPlot} using the specified source file. No properties are set by default.
@@ -187,6 +188,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
         final URI ELLIPSES_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/data/Ellipses.js").toUri();
         final URI CROSSES_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/data/UncertaintyBars.js").toUri();
         final URI CONCORDIA_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/feature/Concordia.js").toUri();
+        final URI REGRESSION_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/feature/Regression.js").toUri();
         final URI EVOLUTION_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/feature/Evolution.js").toUri();
         final URI LAMBDA_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/DefaultLambda.js").toUri();
         final URI UTILS_URI = RESOURCE_EXTRACTOR.extractResourceAsPath("base/Utils.js").toUri();
@@ -196,6 +198,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
                 "<script src=\"" + ELLIPSES_URI + "\"></script>\n" +
                 "<script src=\"" + CROSSES_URI + "\"></script>\n" +
                 "<script src=\"" + CONCORDIA_URI + "\"></script>\n" +
+                "<script src=\"" + REGRESSION_URI + "\"></script>\n" +
                 "<script src=\"" + EVOLUTION_URI + "\"></script>\n" +
                 "<script src=\"" + LAMBDA_URI + "\"></script>\n" +
                 "<script src=\"" + UTILS_URI + "\"></script>\n"
@@ -268,6 +271,7 @@ public abstract class JavaScriptPlot extends AbstractPlot implements JavaFXDispl
                             topsoil = (JSObject) webEngine.executeScript("topsoil");
 
                             topsoil.setMember("bridge", bridge);
+                            topsoil.setMember("regression", regression);
 
                             if (getData() != null) {
                                 topsoil.call("setData", getData());

--- a/core/src/main/java/org/cirdles/topsoil/plot/Regression.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/Regression.java
@@ -22,7 +22,7 @@ public class Regression {
 
         for(int i = 0; i < xDouble.length; i++) {
             xy[i][0] = xDouble[i];
-            xy[i][0] = yDouble[i];
+            xy[i][1] = yDouble[i];
         }
 
         try {

--- a/core/src/main/java/org/cirdles/topsoil/plot/Regression.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/Regression.java
@@ -1,0 +1,111 @@
+package org.cirdles.topsoil.plot;
+
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.cirdles.mcLeanRegression.McLeanRegression;
+import org.cirdles.mcLeanRegression.McLeanRegressionInterface;
+import org.cirdles.mcLeanRegression.core.McLeanRegressionLineInterface;
+
+public class Regression {
+
+    McLeanRegressionLineInterface mcLeanRegressionLine;
+    McLeanRegressionInterface mcLeanRegression = new McLeanRegression();
+
+    //args come in as Strings because arrays can't be passed between JavaScript and Java
+    public McLeanRegressionLineInterface fitLineToDataFor2D(String x, String y, String x1SigmaAbs, String y1SigmaAbs, String rhos) {
+        double[] xDouble = toDouble(x);
+        double[] yDouble = toDouble(y);
+        double[] x1SigmaAbsDouble = toDouble(x1SigmaAbs);
+        double[] y1SigmaAbsDouble = toDouble(y1SigmaAbs);
+        double[] rhosDouble = toDouble(rhos);
+
+        double[][] xy = new double[x.length()][2];
+
+        for(int i = 0; i < xDouble.length; i++) {
+            xy[i][0] = xDouble[i];
+            xy[i][0] = yDouble[i];
+        }
+
+        try {
+            mcLeanRegressionLine = mcLeanRegression.fitLineToDataFor2D(xDouble, yDouble, x1SigmaAbsDouble, y1SigmaAbsDouble, rhosDouble);
+        } catch (Exception e) {
+            // in the case that an uncertainty is not provided, the try block fails and we do an ordinary least squares (OLS)
+            SimpleRegression regression = new SimpleRegression();
+            regression.addData(xy);
+
+            mcLeanRegressionLine = new McLeanOrdinaryLeastSquaresRegressionLine(regression);
+        }
+
+        return mcLeanRegressionLine;
+    }
+
+    public double getIntercept() {
+        //getA()[0][0] is always 0.0
+        //getA()[1][0] is the y-intercept
+        return mcLeanRegressionLine.getA()[1][0];
+    }
+
+    public double getSlope() {
+        return mcLeanRegressionLine.getV()[1][0];
+    }
+
+    public String getV() {
+        return mcLeanRegressionLine.getV()[1].toString();
+    }
+
+    //Convert the strings from the BasePlot.js into double[]
+    private double[] toDouble(String str) {
+        String[] stringList = str.split(",");
+
+        double[] doubleList = new double[stringList.length];
+
+        for(int i = 0; i < stringList.length; i++) {
+            doubleList[i] = Double.parseDouble(stringList[i]);
+        }
+
+        return doubleList;
+    }
+
+    private class McLeanOrdinaryLeastSquaresRegressionLine
+            implements McLeanRegressionLineInterface {
+
+        private SimpleRegression regression;
+        private double[][] a;
+        private double[][] v;
+
+        public McLeanOrdinaryLeastSquaresRegressionLine(SimpleRegression regression) {
+            this.regression = regression;
+
+            a = new double[2][1];
+            a[1][0] = regression.getIntercept();
+
+            v = new double[2][1];
+            v[1][0] = regression.getSlope();
+        }
+
+        @Override
+        public double[][] getA() {
+            return a;
+        }
+
+        @Override
+        public double[][] getV() {
+            return v;
+        }
+
+        @Override
+        public double[][] getSav() {
+            return null;
+        }
+
+        @Override
+        public double getMSWD() {
+            return 0.0;
+        }
+
+        @Override
+        public int getN() {
+            return (int) regression.getN();
+        }
+    }
+
+}

--- a/core/src/main/java/org/cirdles/topsoil/plot/base/BasePlotDefaultProperties.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/base/BasePlotDefaultProperties.java
@@ -38,6 +38,7 @@ public class BasePlotDefaultProperties extends HashMap<String, Object> {
         put(BARS, false);
         put(ISOTOPE_TYPE, "Generic");
         put(CONCORDIA_LINE, false);
+        put(REGRESSION_LINE, false);
         put(EVOLUTION_MATRIX, false);
     }
 

--- a/core/src/main/java/org/cirdles/topsoil/plot/base/BasePlotProperties.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/base/BasePlotProperties.java
@@ -29,6 +29,7 @@ public class BasePlotProperties {
     public static final String LAMBDA_Th230 = "Th230";
     public static final String ISOTOPE_TYPE = "Isotope";
     public static final String CONCORDIA_LINE = "Concordia";
+    public static final String REGRESSION_LINE = "Regression";
     public static final String EVOLUTION_MATRIX = "Evolution";
 
     private BasePlotProperties() {

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
@@ -211,6 +211,9 @@ plot.setData = function (data) {
 
     plot.data = data;
     plot.ellipseData = plot.calcEllipses(plot.data);
+    if (plot.regressionVisible == true) {
+        plot.drawRegressionLine();
+    }
 
     // Updates plot.xDataMin, plot.xDataMax, etc. based on the data.
     plot.updateDataExtent();
@@ -325,7 +328,6 @@ plot.update = function (data) {
     // Manage the plot elements
     plot.managePoints();
     plot.manageEllipses();
-    plot.manageRegressionLine();
     plot.manageRegressionLine();
     plot.manageUncertaintyBars();
     plot.managePlotFeatures();

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
@@ -40,7 +40,8 @@ plot.propertiesKeys = [
     'Bars',
     'Concordia',
     'Evolution',
-    'Isotope'];
+    'Isotope',
+    'Regression'];
 
 /*
     Creates an SVG group for data elements like points and ellipses. Inserting other groups below this one ensures that
@@ -151,9 +152,6 @@ plot.initialize = function (data) {
     // function to manually the x and y axes' extents
     topsoil.setAxes = function() {
 
-        alert("ymin: " + plot.getProperty("Y Min"));
-        alert("ymax: " + plot.getProperty("Y Max"));
-
         // if the user hasn't set a new extent for a field, leave it as-is
         if(plot.getProperty("X Min").length == 0) {
             var xMin = plot.xAxisScale.domain()[0];
@@ -180,8 +178,6 @@ plot.initialize = function (data) {
         if(xMin >= xMax) { xMax = parseFloat(xMin) + 10; }
         if(yMin >= yMax) { yMax = parseFloat(yMin) + 1; }
 
-        alert("ymin: " + yMin);
-        alert("ymax: " + yMax);
         changeAxes(xMin, xMax, yMin, yMax);
     };
 
@@ -227,7 +223,6 @@ plot.setData = function (data) {
     to the plot.
  */
 plot.update = function (data) {
-
     // Makes sure that the plot has been initialized.
     if (!plot.initialized) {
         plot.initialize(data);
@@ -330,6 +325,8 @@ plot.update = function (data) {
     // Manage the plot elements
     plot.managePoints();
     plot.manageEllipses();
+    plot.manageRegressionLine();
+    plot.manageRegressionLine();
     plot.manageUncertaintyBars();
     plot.managePlotFeatures();
 };
@@ -357,6 +354,11 @@ plot.zoomed = function() {
     // re-tick the axes
     plot.area.selectAll(".x.axis").call(plot.xAxis);
     plot.area.selectAll(".y.axis").call(plot.yAxis);
+
+    //If necessary, update the regression line
+    if(plot.regressionVisible) {
+        plot.updateRegressionLine();
+    }
 
     plot.update(topsoil.data);
 };
@@ -438,6 +440,27 @@ plot.manageEllipses = function () {
     // If ellipses should NOT be visible, but are...
     else if (plot.ellipsesVisible) {
         plot.removeEllipses();
+    }
+};
+
+plot.manageRegressionLine = function() {
+    // If RegressionLine shouldn't be visible
+    if(plot.getProperty("Regression")) {
+
+        // If the RegressionLine needs to be updated
+        if (plot.regressionVisible) {
+            plot.updateRegressionLine();
+        }
+
+        //If RegressionLine needs to be drawn
+        else {
+            plot.drawRegressionLine();
+        }
+    }
+
+    //If RegressionLine should not be visible, but is
+    else if (plot.regressionVisible) {
+        plot.removeRegressionLine();
     }
 };
 
@@ -535,6 +558,7 @@ plot.removeDataFeatures = function () {
     Removes all plot features from the plot.
  */
 plot.removePlotFeatures = function () {
+    plot.removeRegressionLine();
     plot.removeConcordia();
     plot.removeEvolutionMatrix();
 };

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Regression.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Regression.js
@@ -1,0 +1,94 @@
+/**
+ * @author Emily Coleman
+ */
+
+if(plot.regressionVisible == null) {
+    plot.regressionVisible = false;
+}
+
+/**
+ *The y-intercept of the McLean Regression line.
+ * @type {number}
+ */
+plot.regressionYIntercept = 0;
+
+/**
+ * The slope of the McLean Regression line.
+ * @type {number}
+ */
+plot.regressionSlope = 0;
+
+/**
+ * Uses the RegressionLine.java class to calculate the McLean Regression.
+ *
+ */
+plot.calculateRegressionLine = function() {
+    var data = plot.data;
+
+    var x_list = [];
+    var y_list = [];
+    var sigma_x_list = [];
+    var sigma_y_list = [];
+    var rho_list = [];
+
+    var fillLists = data.map(function (d) {
+        x_list.push(d.x);
+        y_list.push(d.y);
+        sigma_x_list.push(d.sigma_x);
+        sigma_y_list.push(d.sigma_y);
+        rho_list.push(d.rho);
+    });
+
+    topsoil.regression.fitLineToDataFor2D(x_list.toString(), y_list.toString(), sigma_x_list.toString(), sigma_y_list.toString(), rho_list.toString());
+
+    plot.regressionSlope = topsoil.regression.getSlope();
+    plot.regressionYIntercept = topsoil.regression.getIntercept();
+};
+
+/**
+ * Creates the SVG elements required to display the regression line.
+ */
+plot.drawRegressionLine = function() {
+    plot.calculateRegressionLine();
+
+    // Remove line before redrawing it.
+    if (plot.regressionVisible) {
+        plot.removeRegressionLine();
+    }
+
+    // Create a separate SVG group for the regression line.
+    plot.regressionGroup = plot.area.clipped.insert("g", ".dataGroup")
+        .attr("class", "regressionGroup");
+
+    plot.regressionVisible = true;
+    plot.updateRegressionLine();
+};
+
+plot.updateRegressionLine = function() {
+
+    if (plot.regressionVisible) {
+
+        // Draw a line from point x1, y1 to point x2, y2.
+        x1 = 0;
+        y1 = plot.regressionYIntercept;
+        x2 = plot.xAxisScale.domain()[0];
+        y2 = (plot.regressionSlope * x2) + plot.regressionYIntercept; //y = mx + b
+
+        line = plot.regressionGroup.selectAll(".regression")
+            .append("line")
+            .attr("class", "regression")
+            .attr("x1", x1)
+            .attr("y1", y1)
+            .attr("x2", x2)
+            .attr("y2", y2)
+            .attr("stroke", "black")
+            .attr("stroke-width", 1);
+    }
+};
+
+plot.removeRegressionLine = function() {
+    if (plot.regressionVisible) {
+        plot.regressionGroup.remove();
+        plot.regressionVisible = false;
+    }
+};

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Regression.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Regression.js
@@ -60,6 +60,11 @@ plot.drawRegressionLine = function() {
     plot.regressionGroup = plot.area.clipped.insert("g", ".dataGroup")
         .attr("class", "regressionGroup");
 
+    plot.regressionGroup.append("line")
+        .attr("class", "regression")
+        .attr("stroke", "black")
+        .attr("stroke-width", 1);
+
     plot.regressionVisible = true;
     plot.updateRegressionLine();
 };
@@ -69,20 +74,16 @@ plot.updateRegressionLine = function() {
     if (plot.regressionVisible) {
 
         // Draw a line from point x1, y1 to point x2, y2.
-        x1 = 0;
-        y1 = plot.regressionYIntercept;
-        x2 = plot.xAxisScale.domain()[0];
-        y2 = (plot.regressionSlope * x2) + plot.regressionYIntercept; //y = mx + b
+        var x1 = 0;
+        var y1 = plot.regressionYIntercept;
+        var x2 = plot.xAxisScale.domain()[1];
+        var y2 = (plot.regressionSlope * x2) + plot.regressionYIntercept; //y = mx + b
 
-        line = plot.regressionGroup.selectAll(".regression")
-            .append("line")
-            .attr("class", "regression")
-            .attr("x1", x1)
-            .attr("y1", y1)
-            .attr("x2", x2)
-            .attr("y2", y2)
-            .attr("stroke", "black")
-            .attr("stroke-width", 1);
+        plot.regressionGroup.selectAll(".regression")
+            .attr("x1", plot.xAxisScale(x1))
+            .attr("y1", plot.yAxisScale(y1))
+            .attr("x2", plot.xAxisScale(x2))
+            .attr("y2", plot.yAxisScale(y2));
     }
 };
 


### PR DESCRIPTION
Fixes #326 : 
- Adds an option to draw a regression line for the displayed data in a plot. If the sigma-x and sigma-y variables are set, this line will take error into account. If rho is set as well, it will also be factored in.