### PR TITLE
Add default selections for 'new project' menu

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/util/dialog/controller/ProjectSourcesController.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/util/dialog/controller/ProjectSourcesController.java
@@ -103,6 +103,7 @@ public class ProjectSourcesController {
             }
             updateNextButtonDisabledProperty();
         });
+        toggle.selectToggle(emptyProjectButton);
 
         sourceFileListView.getSelectionModel().selectedItemProperty().addListener(c -> {
             if (sourceFileListView.getSelectionModel().getSelectedItem() == null) {

--- a/app/src/main/java/org/cirdles/topsoil/app/util/dialog/controller/ProjectTitleController.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/util/dialog/controller/ProjectTitleController.java
@@ -60,6 +60,8 @@ public class ProjectTitleController {
         nextButton.setDisable(true);
         projectLocationProperty().addListener(c -> updateNextButtonDisabledProperty());
         titleTextField.textProperty().addListener(c -> updateNextButtonDisabledProperty());
+        //Make home directory the default file location
+        setProjectFile(new File(System.getProperty("user.home")));
     }
 
     /**
@@ -71,7 +73,10 @@ public class ProjectTitleController {
         dirChooser.setTitle("Choose Project Location");
 
         File file = dirChooser.showDialog(MainWindow.getPrimaryStage());
+        setProjectFile(file);
+    }
 
+    private void setProjectFile(File file) {
         if (file != null) {
             String fileName = file.getPath();
 


### PR DESCRIPTION
Fixes #405

"New Project" creation menu now has defaults: the home directory is the default file location, and "new empty project" is the default selected radio button.