### PR TITLE
General Plot Window Enhancements

### DIFF
--- a/app/src/main/java/org/cirdles/topsoil/app/plot/panel/PlotFeaturesController.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/plot/panel/PlotFeaturesController.java
@@ -33,11 +33,13 @@ public class PlotFeaturesController extends AnchorPane {
 
     @FXML private VBox wetherillControls;
     @FXML CheckBox wetherillCheckBox;
+    @FXML CheckBox wetherillEnvelopeCheckBox;
     @FXML ColorPicker wetherillLineFillColorPicker;
     @FXML ColorPicker wetherillEnvelopeFillColorPicker;
 
     @FXML private VBox wasserburgControls;
     @FXML CheckBox wasserburgCheckBox;
+    @FXML CheckBox wasserburgEnvelopeCheckBox;
     @FXML ColorPicker wasserburgLineFillColorPicker;
     @FXML ColorPicker wasserburgEnvelopeFillColorPicker;
 

--- a/app/src/main/java/org/cirdles/topsoil/app/plot/panel/PlotPropertiesPanel.java
+++ b/app/src/main/java/org/cirdles/topsoil/app/plot/panel/PlotPropertiesPanel.java
@@ -322,6 +322,21 @@ public class PlotPropertiesPanel extends Accordion {
         wetherillLineProperty().set(b);
     }
 
+	private BooleanProperty wetherillEnvelope;
+	public BooleanProperty wetherillEnvelopeProperty() {
+		if ( wetherillEnvelope == null) {
+			wetherillEnvelope = new SimpleBooleanProperty();
+			wetherillEnvelope.bindBidirectional(plotFeatures.wetherillEnvelopeCheckBox.selectedProperty());
+		}
+		return wetherillEnvelope;
+	}
+	public final Boolean wetherillEnvelope() {
+		return wetherillEnvelope.get();
+	}
+	public final void setWetherillEnvelope( boolean b ) {
+		wetherillEnvelopeProperty().set(b);
+	}
+
     private ObjectProperty<Color> wetherillLineFill;
     public ObjectProperty<Color> wetherillLineFillProperty() {
     	if (wetherillLineFill == null) {
@@ -370,6 +385,21 @@ public class PlotPropertiesPanel extends Accordion {
 	}
 	public final void setWasserburgLine( boolean b ) {
 		wasserburgLineProperty().set(b);
+	}
+
+	private BooleanProperty wasserburgEnvelope;
+	public BooleanProperty wasserburgEnvelopeProperty() {
+		if ( wasserburgEnvelope == null) {
+			wasserburgEnvelope = new SimpleBooleanProperty();
+			wasserburgEnvelope.bindBidirectional(plotFeatures.wasserburgEnvelopeCheckBox.selectedProperty());
+		}
+		return wasserburgEnvelope;
+	}
+	public final Boolean wasserburgEnvelope() {
+		return wasserburgEnvelope.get();
+	}
+	public final void setWasserburgEnvelope( boolean b ) {
+		wasserburgEnvelopeProperty().set(b);
 	}
 
 	private ObjectProperty<Color> wasserburgLineFill;
@@ -484,12 +514,14 @@ public class PlotPropertiesPanel extends Accordion {
 	    if (properties.containsKey(UNCERTAINTY)) setUncertaintyFormat(UncertaintyFormat.fromValue(
 			    (Double) properties.get(UNCERTAINTY)));
 	    if (properties.containsKey(WETHERILL_LINE)) setWetherillLine((Boolean) properties.get(WETHERILL_LINE));
+		if (properties.containsKey(WETHERILL_ENVELOPE)) setWetherillEnvelope((Boolean) properties.get(WETHERILL_ENVELOPE));
 	    if (properties.containsKey(WETHERILL_LINE_FILL)) setWetherillLineFill(
 	    		Color.valueOf(String.valueOf(properties.get(WETHERILL_LINE_FILL))));
 	    if (properties.containsKey(WETHERILL_ENVELOPE_FILL)) setWetherillEnvelopeFill(
 	    		Color.valueOf(String.valueOf(properties.get(WETHERILL_ENVELOPE_FILL))));
 
 		if (properties.containsKey(WASSERBURG_LINE)) setWasserburgLine((Boolean) properties.get(WASSERBURG_LINE));
+		if (properties.containsKey(WASSERBURG_ENVELOPE)) setWasserburgEnvelope((Boolean) properties.get(WASSERBURG_ENVELOPE));
 		if (properties.containsKey(WASSERBURG_LINE_FILL)) setWasserburgLineFill(
 				Color.valueOf(String.valueOf(properties.get(WASSERBURG_LINE_FILL))));
 		if (properties.containsKey(WASSERBURG_ENVELOPE_FILL)) setWasserburgEnvelopeFill(
@@ -619,6 +651,10 @@ public class PlotPropertiesPanel extends Accordion {
 			properties.put(WETHERILL_LINE, wetherillLine());
     		refreshPlot();
 	    });
+		wetherillEnvelopeProperty().addListener(c -> {
+			properties.put(WETHERILL_ENVELOPE, wetherillEnvelope());
+			refreshPlot();
+		});
     	wetherillLineFillProperty().addListener(c -> {
     		properties.put(WETHERILL_LINE_FILL, convertColor(getWetherillLineFill()));
     		refreshPlot();

--- a/app/src/main/resources/org/cirdles/topsoil/app/plot/panel/plot-features-menu.fxml
+++ b/app/src/main/resources/org/cirdles/topsoil/app/plot/panel/plot-features-menu.fxml
@@ -32,36 +32,38 @@
                         <VBox fx:id="wetherillControls" spacing="5.0">
                            <children>
                               <CheckBox fx:id="wetherillCheckBox" mnemonicParsing="false" text="Wetherill Concordia Line" />
-                              <GridPane>
+                              <GridPane prefWidth="236.0">
                                  <columnConstraints>
                                     <ColumnConstraints hgrow="NEVER" />
                                     <ColumnConstraints hgrow="SOMETIMES" />
                                  </columnConstraints>
                                  <rowConstraints>
+                                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
                                     <RowConstraints vgrow="NEVER" />
                                     <RowConstraints vgrow="NEVER" />
                                  </rowConstraints>
                                  <children>
-                                    <Label text="Line Fill:">
+                                    <Label text="Line Fill:" GridPane.rowIndex="1">
                                        <GridPane.margin>
                                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                        </GridPane.margin>
                                     </Label>
-                                    <Label text="Envelope Fill:" GridPane.rowIndex="1">
+                                    <Label text="Envelope Fill:" GridPane.rowIndex="2">
                                        <GridPane.margin>
                                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                        </GridPane.margin>
                                     </Label>
-                                    <ColorPicker fx:id="wetherillLineFillColorPicker" GridPane.columnIndex="1">
+                                    <ColorPicker fx:id="wetherillLineFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="1">
                                        <GridPane.margin>
                                           <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                                        </GridPane.margin>
                                     </ColorPicker>
-                                    <ColorPicker fx:id="wetherillEnvelopeFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                    <ColorPicker fx:id="wetherillEnvelopeFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="2">
                                        <GridPane.margin>
                                           <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                                        </GridPane.margin>
                                     </ColorPicker>
+                                    <CheckBox fx:id="wetherillEnvelopeCheckBox" mnemonicParsing="false" text="Uncertainty Envelope" GridPane.columnSpan="2147483647" />
                                  </children>
                                  <VBox.margin>
                                     <Insets left="25.0" />
@@ -83,30 +85,32 @@
                                     <ColumnConstraints hgrow="SOMETIMES" />
                                  </columnConstraints>
                                  <rowConstraints>
+                                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
                                     <RowConstraints vgrow="NEVER" />
                                     <RowConstraints vgrow="NEVER" />
                                  </rowConstraints>
                                  <children>
-                                    <Label text="Line Fill:">
+                                    <Label text="Line Fill:" GridPane.rowIndex="1">
                                        <GridPane.margin>
                                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                        </GridPane.margin>
                                     </Label>
-                                    <Label text="Envelope Fill:" GridPane.rowIndex="1">
+                                    <Label text="Envelope Fill:" GridPane.rowIndex="2">
                                        <GridPane.margin>
                                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                        </GridPane.margin>
                                     </Label>
-                                    <ColorPicker fx:id="wasserburgLineFillColorPicker" GridPane.columnIndex="1">
+                                    <ColorPicker fx:id="wasserburgLineFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="1">
                                        <GridPane.margin>
                                           <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                                        </GridPane.margin>
                                     </ColorPicker>
-                                    <ColorPicker fx:id="wasserburgEnvelopeFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                    <ColorPicker fx:id="wasserburgEnvelopeFillColorPicker" GridPane.columnIndex="1" GridPane.rowIndex="2">
                                        <GridPane.margin>
                                           <Insets bottom="3.0" left="3.0" right="3.0" top="3.0" />
                                        </GridPane.margin>
                                     </ColorPicker>
+                                    <CheckBox fx:id="wasserburgEnvelopeCheckBox" mnemonicParsing="false" text="Uncertainty Envelope" GridPane.columnSpan="2147483647" />
                                  </children>
                                  <VBox.margin>
                                     <Insets left="25.0" />

--- a/core/src/main/java/org/cirdles/topsoil/plot/DefaultProperties.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/DefaultProperties.java
@@ -25,7 +25,7 @@ public class DefaultProperties extends HashMap<PlotProperty, Object> {
 	    put(POINTS_FILL, "steelblue");
 	    put(POINTS_OPACITY, 1.0);
 
-	    put(ELLIPSES, false);
+	    put(ELLIPSES, true);
 	    put(ELLIPSES_FILL, "red");
 	    put(ELLIPSES_OPACITY, 1.0);
 
@@ -33,10 +33,12 @@ public class DefaultProperties extends HashMap<PlotProperty, Object> {
 	    put(UNCTBARS_FILL, "black");
 	    put(UNCTBARS_OPACITY, 1.0);
 
-	    put(WETHERILL_LINE, false);
+	    put(WETHERILL_LINE, true);
+		put(WETHERILL_ENVELOPE, false);
 	    put(WETHERILL_LINE_FILL, "blue");
 	    put(WETHERILL_ENVELOPE_FILL, "lightgray");
 		put(WASSERBURG_LINE, false);
+		put(WASSERBURG_ENVELOPE, false);
 		put(WASSERBURG_LINE_FILL, "blue");
 		put(WASSERBURG_ENVELOPE_FILL, "lightgray");
 	    put(MCLEAN_REGRESSION, false);

--- a/core/src/main/java/org/cirdles/topsoil/plot/PlotProperty.java
+++ b/core/src/main/java/org/cirdles/topsoil/plot/PlotProperty.java
@@ -28,9 +28,11 @@ public enum PlotProperty {
 	UNCTBARS_OPACITY("Unct Bars Opacity"),
 
 	WETHERILL_LINE("Wetherill Line"),
+	WETHERILL_ENVELOPE("Wetherill Envelope"),
 	WETHERILL_LINE_FILL("Wetherill Line Fill"),
 	WETHERILL_ENVELOPE_FILL("Wetherill Envelope Fill"),
 	WASSERBURG_LINE("Wasserburg Line"),
+	WASSERBURG_ENVELOPE("Wasserburg Envelope"),
 	WASSERBURG_LINE_FILL("Wasserburg Line Fill"),
 	WASSERBURG_ENVELOPE_FILL("Wasserburg Envelope Fill"),
 	EVOLUTION("Evolution Matrix"),

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/BasePlot.js
@@ -39,9 +39,11 @@ plot.propertiesKeys = [
     'Unct Bars Opacity',
 
     'Wetherill Line',
+    'Wetherill Envelope',
     'Wetherill Line Fill',
     'Wetherill Envelope Fill',
     'Wasserburg Line',
+    'Wasserburg Envelope',
     'Wasserburg Line Fill',
     'Wasserburg Envelope Fill',
     'Evolution Matrix',
@@ -90,7 +92,7 @@ plot.initialize = function (data) {
         .attr("class", "label")
         .style("font-size", "16px")
         .attr("x", plot.width / 2)
-        .attr("y", 45);
+        .attr("y", -10);
 
     //create y axis label
     plot.area.append("g")
@@ -100,7 +102,7 @@ plot.initialize = function (data) {
         .attr("transform", "rotate(-90)")
         .style("font-size", "16px")
         .attr("x", -plot.height / 2)
-        .attr("y", -50)
+        .attr("y", 15)
         .attr("dy", ".1em");
 
     // defaults if no data is provided
@@ -225,6 +227,8 @@ plot.initialize = function (data) {
         changeAxes( concordiaXMin, concordiaXMax, concordiaYMin, concordiaYMax );
         
     };
+
+    //Helper function that will bring the concordia line to the front
 
     plot.initialized = true;
     plot.manageAxisExtents();
@@ -547,7 +551,7 @@ plot.managePlotFeatures = function () {
             }
             // If the concordia line should be visible, and already is...
             else {
-                plot.updateConcordia();
+                plot.drawConcordia();
             }
         }
 
@@ -561,7 +565,7 @@ plot.managePlotFeatures = function () {
                 plot.drawTWConcordia();
             }
             else {
-                plot.updateTWConcordia();
+                plot.drawTWConcordia();
             }
         }
         else if (plot.twconcordiaVisible) {

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Concordia.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/Concordia.js
@@ -112,80 +112,82 @@ plot.updateConcordia = function() {
             .attr("stroke", plot.getProperty('Wetherill Line Fill'))
             .attr("stroke-width", 2);
 
-        plot.concordiaGroup.select(".uncertaintyEnvelope")
-            .attr("d", function () {
-                var approximateUpperSegment = function (path, minT, maxT) {
-                    var p1 = wetherill.upperEnvelope(minT).plus(
-                        wetherill.prime(minT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p2 = wetherill.upperEnvelope(maxT).minus(
-                        wetherill.prime(maxT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p3 = wetherill.upperEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
+        if (plot.getProperty("Wetherill Envelope")) {
+            plot.concordiaGroup.select(".uncertaintyEnvelope")
+                .attr("d", function () {
+                    var approximateUpperSegment = function (path, minT, maxT) {
+                        var p1 = wetherill.upperEnvelope(minT).plus(
+                            wetherill.prime(minT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p2 = wetherill.upperEnvelope(maxT).minus(
+                            wetherill.prime(maxT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p3 = wetherill.upperEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
 
-                    // append a cubic bezier to the path
-                    plot.cubicBezier(path, p1, p2, p3);
-                };
+                        // append a cubic bezier to the path
+                        plot.cubicBezier(path, p1, p2, p3);
+                    };
 
-                var approximateLowerSegment = function (path, minT, maxT) {
-                    var p1 = wetherill.lowerEnvelope(minT).plus(
-                        wetherill.prime(minT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p2 = wetherill.lowerEnvelope(maxT).minus(
-                        wetherill.prime(maxT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p3 = wetherill.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
+                    var approximateLowerSegment = function (path, minT, maxT) {
+                        var p1 = wetherill.lowerEnvelope(minT).plus(
+                            wetherill.prime(minT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p2 = wetherill.lowerEnvelope(maxT).minus(
+                            wetherill.prime(maxT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p3 = wetherill.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
 
-                    // append a cubic bezier to the path
-                    plot.cubicBezier(path, p1, p2, p3);
-                };
+                        // append a cubic bezier to the path
+                        plot.cubicBezier(path, p1, p2, p3);
+                    };
 
-                var minT = Math.max(
-                    newtonMethod(wetherill.upperEnvelope.x, plot.xAxisScale.domain()[0]),
-                    newtonMethod(wetherill.upperEnvelope.y, plot.yAxisScale.domain()[0]));
+                    var minT = Math.max(
+                        newtonMethod(wetherill.upperEnvelope.x, plot.xAxisScale.domain()[0]),
+                        newtonMethod(wetherill.upperEnvelope.y, plot.yAxisScale.domain()[0]));
 
-                var maxT = Math.min(
-                    newtonMethod(wetherill.upperEnvelope.x, plot.xAxisScale.domain()[1]),
-                    newtonMethod(wetherill.upperEnvelope.y, plot.yAxisScale.domain()[1]));
+                    var maxT = Math.min(
+                        newtonMethod(wetherill.upperEnvelope.x, plot.xAxisScale.domain()[1]),
+                        newtonMethod(wetherill.upperEnvelope.y, plot.yAxisScale.domain()[1]));
 
-                // initialize path
-                var path = [];
-                moveTo(path, wetherill.upperEnvelope(minT).scaleBy(plot.xAxisScale, plot.yAxisScale));
+                    // initialize path
+                    var path = [];
+                    moveTo(path, wetherill.upperEnvelope(minT).scaleBy(plot.xAxisScale, plot.yAxisScale));
 
-                // determine the step size using the number of pieces
-                var pieces = 30;
-                var stepSize = (maxT - minT) / pieces;
+                    // determine the step size using the number of pieces
+                    var pieces = 30;
+                    var stepSize = (maxT - minT) / pieces;
 
-                // build the pieces
-                for (var i = 0; i < pieces; i++) {
-                    approximateUpperSegment(path, minT + stepSize * i, minT + stepSize * (i + 1));
-                }
+                    // build the pieces
+                    for (var i = 0; i < pieces; i++) {
+                        approximateUpperSegment(path, minT + stepSize * i, minT + stepSize * (i + 1));
+                    }
 
-                lineTo(path, [plot.xAxisScale.range()[1], plot.yAxisScale.range()[1]]);
+                    lineTo(path, [plot.xAxisScale.range()[1], plot.yAxisScale.range()[1]]);
 
-                minT = Math.max(
-                    newtonMethod(wetherill.lowerEnvelope.x, plot.xAxisScale.domain()[0]),
-                    newtonMethod(wetherill.lowerEnvelope.y, plot.yAxisScale.domain()[0]));
+                    minT = Math.max(
+                        newtonMethod(wetherill.lowerEnvelope.x, plot.xAxisScale.domain()[0]),
+                        newtonMethod(wetherill.lowerEnvelope.y, plot.yAxisScale.domain()[0]));
 
-                maxT = Math.min(
-                    newtonMethod(wetherill.lowerEnvelope.x, plot.xAxisScale.domain()[1]),
-                    newtonMethod(wetherill.lowerEnvelope.y, plot.yAxisScale.domain()[1]));
+                    maxT = Math.min(
+                        newtonMethod(wetherill.lowerEnvelope.x, plot.xAxisScale.domain()[1]),
+                        newtonMethod(wetherill.lowerEnvelope.y, plot.yAxisScale.domain()[1]));
 
-                lineTo(path, wetherill.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale));
+                    lineTo(path, wetherill.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale));
 
-                stepSize = (maxT - minT) / pieces;
+                    stepSize = (maxT - minT) / pieces;
 
-                // build the pieces
-                for (i = 0; i < pieces; i++) {
-                    approximateLowerSegment(path, maxT - stepSize * i, maxT - stepSize * (i + 1));
-                }
+                    // build the pieces
+                    for (i = 0; i < pieces; i++) {
+                        approximateLowerSegment(path, maxT - stepSize * i, maxT - stepSize * (i + 1));
+                    }
 
-                lineTo(path, [plot.xAxisScale.range()[0], plot.yAxisScale.range()[0]]);
-                close(path);
+                    lineTo(path, [plot.xAxisScale.range()[0], plot.yAxisScale.range()[0]]);
+                    close(path);
 
-                return path.join("");
-            })
-            .attr("fill", plot.getProperty('Wetherill Envelope Fill'));
+                    return path.join("");
+                })
+                .attr("fill", plot.getProperty('Wetherill Envelope Fill'));
+        }
 
         plot.t.domain([minT, maxT]);
 
@@ -195,7 +197,10 @@ plot.updateConcordia = function() {
             .enter()
             .append("circle")
             .attr("class", "concordiaTicks")
-            .attr("r", 5);
+            .attr("r", 5)
+            .style('stroke-width', 2)
+            .style("stroke", "black")
+            .style("fill", "white");
 
         concordiaTicks
             .attr("cx", function (t) {

--- a/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/TWConcordia.js
+++ b/core/src/main/resources/org/cirdles/topsoil/plot/base/feature/TWConcordia.js
@@ -121,81 +121,83 @@ plot.updateTWConcordia = function() {
             .attr("stroke", plot.getProperty('Wasserburg Line Fill'))
             .attr("stroke-width", 2);
 
-        plot.twconcordiaGroup.select(".twuncertaintyEnvelope")
-            .attr("d", function () {
-                var approximateUpperSegment = function (path, minT, maxT) {
-                    var p1 = wasserburg.upperEnvelope(minT).plus(
-                        wasserburg.prime(minT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p2 = wasserburg.upperEnvelope(maxT).minus(
-                        wasserburg.prime(maxT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p3 = wasserburg.upperEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
+        if (plot.getProperty("Wasserburg Envelope")) {
+            plot.twconcordiaGroup.select(".twuncertaintyEnvelope")
+                .attr("d", function () {
+                    var approximateUpperSegment = function (path, minT, maxT) {
+                        var p1 = wasserburg.upperEnvelope(minT).plus(
+                            wasserburg.prime(minT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p2 = wasserburg.upperEnvelope(maxT).minus(
+                            wasserburg.prime(maxT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p3 = wasserburg.upperEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
 
-                    // append a cubic bezier to the path
-                    plot.cubicBezier(path, p1, p2, p3);
-                };
+                        // append a cubic bezier to the path
+                        plot.cubicBezier(path, p1, p2, p3);
+                    };
 
-                var approximateLowerSegment = function (path, minT, maxT) {
-                    var p1 = wasserburg.lowerEnvelope(minT).plus(
-                        wasserburg.prime(minT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p2 = wasserburg.lowerEnvelope(maxT).minus(
-                        wasserburg.prime(maxT).times((maxT - minT) / 3))
-                        .scaleBy(plot.xAxisScale, plot.yAxisScale);
-                    var p3 = wasserburg.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
+                    var approximateLowerSegment = function (path, minT, maxT) {
+                        var p1 = wasserburg.lowerEnvelope(minT).plus(
+                            wasserburg.prime(minT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p2 = wasserburg.lowerEnvelope(maxT).minus(
+                            wasserburg.prime(maxT).times((maxT - minT) / 3))
+                            .scaleBy(plot.xAxisScale, plot.yAxisScale);
+                        var p3 = wasserburg.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale);
 
-                    // append a cubic bezier to the path
-                    plot.cubicBezier(path, p1, p2, p3);
-                };
+                        // append a cubic bezier to the path
+                        plot.cubicBezier(path, p1, p2, p3);
+                    };
 
-                var minT = Math.min(
-                    newtonMethod(wasserburg.upperEnvelope.x, plot.xAxisScale.domain()[0]),
-                    newtonMethod(wasserburg.upperEnvelope.y, plot.yAxisScale.domain()[0]));
+                    var minT = Math.min(
+                        newtonMethod(wasserburg.upperEnvelope.x, plot.xAxisScale.domain()[0]),
+                        newtonMethod(wasserburg.upperEnvelope.y, plot.yAxisScale.domain()[0]));
 
-                var maxT = Math.min(
-                    newtonMethod(wasserburg.upperEnvelope.x, plot.xAxisScale.domain()[1]),
-                    newtonMethod(wasserburg.upperEnvelope.y, plot.yAxisScale.domain()[1]));
+                    var maxT = Math.min(
+                        newtonMethod(wasserburg.upperEnvelope.x, plot.xAxisScale.domain()[1]),
+                        newtonMethod(wasserburg.upperEnvelope.y, plot.yAxisScale.domain()[1]));
 
 
-                // initialize path
-                var path = [];
-                moveTo(path, wasserburg.upperEnvelope(minT).scaleBy(plot.xAxisScale, plot.yAxisScale));
+                    // initialize path
+                    var path = [];
+                    moveTo(path, wasserburg.upperEnvelope(minT).scaleBy(plot.xAxisScale, plot.yAxisScale));
 
-                // determine the step size using the number of pieces
-                var pieces = 30;
-                var stepSize = (maxT - minT) / pieces;
+                    // determine the step size using the number of pieces
+                    var pieces = 30;
+                    var stepSize = (maxT - minT) / pieces;
 
-                // build the pieces
-                for (var i = 0; i < pieces; i++) {
-                    approximateUpperSegment(path, minT + stepSize * i, minT + stepSize * (i + 1));
-                }
+                    // build the pieces
+                    for (var i = 0; i < pieces; i++) {
+                        approximateUpperSegment(path, minT + stepSize * i, minT + stepSize * (i + 1));
+                    }
 
-                lineTo(path, [plot.xAxisScale.range()[1], plot.yAxisScale.range()[1]]);
+                    lineTo(path, [plot.xAxisScale.range()[1], plot.yAxisScale.range()[1]]);
 
-                minT = Math.min(
-                    newtonMethod(wasserburg.lowerEnvelope.x, plot.xAxisScale.domain()[0]),
-                    newtonMethod(wasserburg.lowerEnvelope.y, plot.yAxisScale.domain()[0]));
+                    minT = Math.min(
+                        newtonMethod(wasserburg.lowerEnvelope.x, plot.xAxisScale.domain()[0]),
+                        newtonMethod(wasserburg.lowerEnvelope.y, plot.yAxisScale.domain()[0]));
 
-                maxT = Math.min(
-                    newtonMethod(wasserburg.lowerEnvelope.x, plot.xAxisScale.domain()[1]),
-                    newtonMethod(wasserburg.lowerEnvelope.y, plot.yAxisScale.domain()[1]));
+                    maxT = Math.min(
+                        newtonMethod(wasserburg.lowerEnvelope.x, plot.xAxisScale.domain()[1]),
+                        newtonMethod(wasserburg.lowerEnvelope.y, plot.yAxisScale.domain()[1]));
 
-                lineTo(path, wasserburg.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale));
+                    lineTo(path, wasserburg.lowerEnvelope(maxT).scaleBy(plot.xAxisScale, plot.yAxisScale));
 
-                stepSize = (maxT - minT) / pieces;
+                    stepSize = (maxT - minT) / pieces;
 
-                // build the pieces
-                for (i = 0; i < pieces; i++) {
-                    approximateLowerSegment(path, maxT - stepSize * i, maxT - stepSize * (i + 1));
-                }
+                    // build the pieces
+                    for (i = 0; i < pieces; i++) {
+                        approximateLowerSegment(path, maxT - stepSize * i, maxT - stepSize * (i + 1));
+                    }
 
-                lineTo(path, [plot.xAxisScale.range()[0], plot.yAxisScale.range()[0]]);
-                close(path);
+                    lineTo(path, [plot.xAxisScale.range()[0], plot.yAxisScale.range()[0]]);
+                    close(path);
 
-                return path.join("");
-            })
-            .attr("fill", plot.getProperty('Wasserburg Envelope Fill'));
+                    return path.join("");
+                })
+                .attr("fill", plot.getProperty('Wasserburg Envelope Fill'));
+        }
 
         plot.t.domain([minT, maxT]);
 
@@ -205,7 +207,10 @@ plot.updateTWConcordia = function() {
             .enter()
             .append("circle")
             .attr("class", "concordiaTicks")
-            .attr("r", 5);
+            .attr("r", 5)
+            .style('stroke-width', 2)
+            .style("stroke", "black")
+            .style("fill", "white");;
 
         concordiaTicks
             .attr("cx", function (t) {


### PR DESCRIPTION
- X and Y axis labels are now contained within the graph area of a plot. This better reflects how plots are displayed in other CIRDLES applications.
- Envelopes for Concordia lines can now be toggled on and off.
- Age points on Concordia lines are now unfilled circles to better reflect the general style of Concordia plots within other CIRDLES applications.
- The default view for plots now already has the Wetherill Concordia line and ellipses selected