### PR TITLE
JxBrowser Error on Mac 

### DIFF
--- a/topsoilApp/src/main/java/org/cirdles/topsoil/app/Topsoil.java
+++ b/topsoilApp/src/main/java/org/cirdles/topsoil/app/Topsoil.java
@@ -77,7 +77,7 @@ public class Topsoil extends Application {
                 "--enable-logging --v=1"
         );
         if (Environment.isMac()) {
-            BrowserCore.initialize();   // must be initialized on non-UI thread on Mac
+            //BrowserCore.initialize();   // must be initialized on non-UI thread on Mac
         }
     }
 


### PR DESCRIPTION
Simply removes the mac browser core initialization.