### PR TITLE
Increased Selected column width to 70.0 px

### DIFF
--- a/topsoilApp/src/main/java/org/cirdles/topsoil/app/control/data/FXDataTableViewer.java
+++ b/topsoilApp/src/main/java/org/cirdles/topsoil/app/control/data/FXDataTableViewer.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
 public class FXDataTableViewer extends SingleChildRegion<TreeTableView<FXDataRow>> {
 
     private static final double LABEL_COL_WIDTH = 150.0;
-    private static final double SELECTED_COL_WIDTH = 65.0;
+    private static final double SELECTED_COL_WIDTH = 70.0;
     private static final double DATA_COL_WIDTH = 145.0;
 
     private FXDataTable table;


### PR DESCRIPTION
Will prevent "Selected" from taking up two lines ("Selecte\nd") on both Macs and PCs